### PR TITLE
Remove circular association

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@
 .c9/
 .gitignore
 .bashrc
+
+# Ignore RubyMine files
+.idea

--- a/app/models/race_edition.rb
+++ b/app/models/race_edition.rb
@@ -1,7 +1,6 @@
 class RaceEdition < ActiveRecord::Base
    belongs_to :race
-   has_many :race_editions
-   
+
    validates :race_id, presence: true
    validates :date, presence: true
  end


### PR DESCRIPTION
I'm pretty sure the RaceEdition model is not intended to have many race_editions, but I could be missing something. Also updated .gitignore to ignore RubyMine (.idea) files.