### PR TITLE
Add strip_attributes gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,7 @@ gem 'american_date', '~> 1.1'
 gem 'friendly_id', '~> 5.1.0'
 gem 'rest-client', '~> 2.0'
 gem 'dotenv-rails', '~> 2.2'
+gem 'strip_attributes', '~> 1.8'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -215,6 +215,8 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     sqlite3 (1.3.13)
+    strip_attributes (1.8.0)
+      activemodel (>= 3.0, < 6.0)
     thor (0.19.4)
     thread_safe (0.3.6)
     tilt (2.0.8)
@@ -269,6 +271,7 @@ DEPENDENCIES
   spring
   spring-watcher-listen (~> 2.0.0)
   sqlite3
+  strip_attributes (~> 1.8)
   turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)

--- a/app/models/race.rb
+++ b/app/models/race.rb
@@ -1,5 +1,6 @@
 class Race < ActiveRecord::Base
   extend FriendlyId
+  strip_attributes collapse_spaces: true
 
   has_many :race_editions
   validates :name, presence: true, length: { minimum: 5, maximum: 100 }

--- a/app/models/racer.rb
+++ b/app/models/racer.rb
@@ -1,6 +1,7 @@
 class Racer < ActiveRecord::Base
   has_many :race_entries, dependent: :destroy
   enum gender: [:male, :female]
+  strip_attributes collapse_spaces: true
 
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
 

--- a/spec/models/race_spec.rb
+++ b/spec/models/race_spec.rb
@@ -5,6 +5,8 @@ require 'rails_helper'
 # t.text "location"
 
 RSpec.describe Race, type: :model do
+  it { is_expected.to strip_attribute(:name).collapse_spaces }
+
   describe '#initialize' do
     it 'is valid when created with a name' do
       race = build_stubbed(:race)

--- a/spec/models/racer_spec.rb
+++ b/spec/models/racer_spec.rb
@@ -10,6 +10,11 @@ require 'rails_helper'
 
 RSpec.describe Racer, type: :model do
   include ActiveSupport::Testing::TimeHelpers
+  it { is_expected.to strip_attribute(:first_name).collapse_spaces }
+  it { is_expected.to strip_attribute(:last_name).collapse_spaces }
+  it { is_expected.to strip_attribute(:city).collapse_spaces }
+  it { is_expected.to strip_attribute(:state).collapse_spaces }
+  it { is_expected.to strip_attribute(:email).collapse_spaces }
 
   describe '#initialize' do
     it 'is valid when created with first_name, last_name, gender, email, and birth_date' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,7 +13,12 @@
 # it.
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+
+require 'strip_attributes/matchers'
+
 RSpec.configure do |config|
+  config.include StripAttributes::Matchers
+
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.


### PR DESCRIPTION
This will ensure leading and trailing spaces are stripped from strings before saving to the database. Installation of the gem affects only future records, but we can use it to take care of existing trailing spaces as well. After installation, we can run a couple of lines from the console to strip spaces from existing records, like this: 

`Racer.find_each(&:save)`
`Race.find_each(&:save)`

The gem is triggered by a before_save callback, so the act of saving existing records will perform the strip.