### PR TITLE
Validate birthdates

### DIFF
--- a/app/models/concerns/birth_date_validator.rb
+++ b/app/models/concerns/birth_date_validator.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class BirthDateValidator < ActiveModel::Validator
+  def validate(record)
+    if record.birth_date.present? && (record.birth_date < '1900-01-01'.to_date)
+      record.errors.add(:birth_date, "can't be before 1900")
+    end
+    if record.birth_date.present? && (record.birth_date > Date.today)
+      record.errors.add(:birth_date, "can't be in the future")
+    end
+  end
+end

--- a/app/models/race_entry.rb
+++ b/app/models/race_entry.rb
@@ -10,6 +10,8 @@ class RaceEntry < ActiveRecord::Base
   validates :race_edition, presence: true
   validates_uniqueness_of :racer_id, scope: :race_edition_id,
                           message: 'may be added to a race_edition only once'
+  validates_uniqueness_of :bib_number, scope: :race_edition_id,
+                          message: 'may not be duplicated within a race edition'
 
   after_initialize :default_values
 

--- a/app/models/racer.rb
+++ b/app/models/racer.rb
@@ -15,6 +15,7 @@ class Racer < ActiveRecord::Base
   validates :gender, presence: true
   validates :email, presence: true, format: {with: VALID_EMAIL_REGEX}
   validates :birth_date, presence: true
+  validates_with BirthDateValidator
 
   def name
     first_name + ' ' + last_name

--- a/app/models/racer.rb
+++ b/app/models/racer.rb
@@ -5,27 +5,44 @@ class Racer < ActiveRecord::Base
 
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
 
-  before_save {
-    self.email = self.email.downcase  
-  }
-  
+  before_save do
+    downcase_email
+    modernize_birth_date
+  end
+
   validates :first_name, presence: true
   validates :last_name, presence: true
   validates :gender, presence: true
-  validates :email, presence: true, format: { with: VALID_EMAIL_REGEX }
+  validates :email, presence: true, format: {with: VALID_EMAIL_REGEX}
   validates :birth_date, presence: true
-  
+
   def name
     first_name + ' ' + last_name
   end
-  
+
   def current_age
     now = Time.now.utc.to_date
     dob = self.birth_date
     now.year - dob.year - ((now.month > dob.month || (now.month == dob.month && now.day >= dob.day)) ? 0 : 1)
   end
-  
+
   def home_location
     [city.presence, state.presence].compact.join(', ')
+  end
+
+  private
+
+  def downcase_email
+    self.email = email&.downcase
+  end
+
+  def modernize_birth_date
+    return unless birth_date
+
+    if birth_date.year <= Date.today.year % 100
+      self.birth_date += 2000.years
+    elsif birth_date.year <= Date.today.year % 100 + 100
+      self.birth_date += 1900.years
+    end
   end
 end

--- a/spec/factories/racer.rb
+++ b/spec/factories/racer.rb
@@ -4,7 +4,7 @@ FactoryGirl.define do
     last_name { FFaker::Name.last_name }
     gender { FFaker::Gender.random }
     email { FFaker::Internet.disposable_email }
-    birth_date { FFaker::Time.date }
+    birth_date { Date.current - rand(10..80).years }
 
     trait :male do
       gender :male

--- a/spec/models/race_entry_spec.rb
+++ b/spec/models/race_entry_spec.rb
@@ -31,6 +31,13 @@ RSpec.describe RaceEntry, type: :model do
       expect(new_entry).to be_invalid
       expect(new_entry.errors.full_messages).to include('Racer may be added to a race_edition only once')
     end
+
+    it 'is invalid when a bib_number already exists within the race_edition' do
+      existing_entry = create(:race_entry)
+      new_entry = build(:race_entry, bib_number: existing_entry.bib_number, race_edition: existing_entry.race_edition)
+      expect(new_entry).to be_invalid
+      expect(new_entry.errors.full_messages).to include('Bib number may not be duplicated within a race edition')
+    end
   end
 
   describe '#elapsed_time' do

--- a/spec/models/race_entry_spec.rb
+++ b/spec/models/race_entry_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 # t.integer "racer_id"
 # t.integer "race_edition_id"
 # t.integer "time"
+# t.boolean "paid", default: false
+# t.integer "bib_number"
 
 RSpec.describe RaceEntry, type: :model do
   describe '#initialize' do

--- a/spec/models/racer_spec.rb
+++ b/spec/models/racer_spec.rb
@@ -93,6 +93,25 @@ RSpec.describe Racer, type: :model do
       end
     end
 
+    context 'when email is nil' do
+      let(:email) { nil }
+
+      it 'does not raise an error and makes no changes' do
+        expect { subject.run_callbacks :save }.not_to raise_error
+        expect(subject.email).to be_nil
+      end
+    end
+
+    context 'when birth_date year is provided as four digits' do
+      let(:birth_date) { '1/1/1990' }
+
+      it 'makes no change' do
+        expect(subject.birth_date.year).to eq(1990)
+        subject.run_callbacks :save
+        expect(subject.birth_date.year).to eq(1990)
+      end
+    end
+
     context 'when birth_date year is provided as two digits that are between 0 and the current two-digit year' do
       let(:birth_date) { '1/1/08' }
 
@@ -110,6 +129,15 @@ RSpec.describe Racer, type: :model do
         expect(subject.birth_date.year).to eq(88)
         subject.run_callbacks :save
         expect(subject.birth_date.year).to eq(1988)
+      end
+    end
+
+    context 'when birth_date is nil' do
+      let(:birth_date) { nil }
+
+      it 'does not raise an error and makes no changes' do
+        expect { subject.run_callbacks :save }.not_to raise_error
+        expect(subject.birth_date).to be_nil
       end
     end
   end

--- a/spec/models/racer_spec.rb
+++ b/spec/models/racer_spec.rb
@@ -77,6 +77,23 @@ RSpec.describe Racer, type: :model do
         expect(racer.errors.full_messages).to include('Email is invalid')
       end
     end
+
+    it 'permits birth_dates after 1900 and before the current date' do
+      racer = build_stubbed(:racer, birth_date: '1980-01-01')
+      expect(racer).to be_valid
+    end
+
+    it 'rejects birth_dates before 1900' do
+      racer = build_stubbed(:racer, birth_date: '1800-01-01')
+      expect(racer).to be_invalid
+      expect(racer.errors.full_messages).to include("Birth date can't be before 1900")
+    end
+
+    it 'rejects birth_dates after the current date' do
+      racer = build_stubbed(:racer, birth_date: '2030-01-01')
+      expect(racer).to be_invalid
+      expect(racer.errors.full_messages).to include("Birth date can't be in the future")
+    end
   end
 
   describe 'before_save callbacks' do

--- a/spec/models/racer_spec.rb
+++ b/spec/models/racer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 # t.string "first_name"
@@ -73,6 +75,41 @@ RSpec.describe Racer, type: :model do
         racer = build_stubbed(:racer, email: email)
         expect(racer).to be_invalid
         expect(racer.errors.full_messages).to include('Email is invalid')
+      end
+    end
+  end
+
+  describe 'before_save callbacks' do
+    subject { build(:racer, email: email, birth_date: birth_date) }
+    let(:email) { 'mail@example.com' }
+    let(:birth_date) { '1/1/1970' }
+
+    context 'when email contains uppercase characters' do
+      let(:email) { 'Bill.Wright@Example.com' }
+
+      it 'changes email to lowercase' do
+        subject.run_callbacks :save
+        expect(subject.email).to eq('bill.wright@example.com')
+      end
+    end
+
+    context 'when birth_date year is provided as two digits that are between 0 and the current two-digit year' do
+      let(:birth_date) { '1/1/08' }
+
+      it 'adds 2000 to the year' do
+        expect(subject.birth_date.year).to eq(8)
+        subject.run_callbacks :save
+        expect(subject.birth_date.year).to eq(2008)
+      end
+    end
+
+    context 'when birth_date year is provided as two digits that are between the current two-digit year and 99' do
+      let(:birth_date) { '1/1/88' }
+
+      it 'adds 1900 to the year' do
+        expect(subject.birth_date.year).to eq(88)
+        subject.run_callbacks :save
+        expect(subject.birth_date.year).to eq(1988)
       end
     end
   end

--- a/spec/presenters/race_edition_presenter_spec.rb
+++ b/spec/presenters/race_edition_presenter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe RaceEditionPresenter do
@@ -17,8 +19,8 @@ RSpec.describe RaceEditionPresenter do
       let(:race) { build_stubbed(:race, name: '2018 Ramble') }
 
       it 'uses the adult categories' do
-        expect(subject.category_size_map.size).to eq(8)
-        expect(subject.category_size_map.map(&:first)).to eq(['Under 20 Men', 'Under 20 Women', '20 to 29 Men', '20 to 29 Women', '30 to 39 Men', '30 to 39 Women', 'Masters Men (40+)', 'Masters Women (40+)'])
+        expect(subject.category_size_map.size).to eq(12)
+        expect(subject.category_size_map.map(&:first)).to eq(['Under 20 Men', 'Under 20 Women', '20 to 29 Men', '20 to 29 Women', '30 to 39 Men', '30 to 39 Women', '40 to 49 Men', '40 to 49 Women', '50 to 59 Men', '50 to 59 Women', '60+ Men', '60+ Women'])
       end
     end
 


### PR DESCRIPTION
Fixes the problem of two-digit birthdates being interpreted as being xx years from 0 (for example, 3/15/08 being interpreted as March 15, 0008). Addresses #39.

This PR implements a before_save callback that interprets two-digit year dates as being in the 1900s or 2000s, as appropriate.