### PR TITLE
Add start time offsets

### DIFF
--- a/app/controllers/race_editions_controller.rb
+++ b/app/controllers/race_editions_controller.rb
@@ -92,7 +92,8 @@ class RaceEditionsController < ApplicationController
 
   def obj_params
     params.require(:race_edition)
-        .permit(:date, racers_attributes: [:id, :first_name, :last_name, :email, :gender, :birth_date, :city, :state])
+        .permit(:date, :male_offset_minutes, :female_offset_minutes,
+                racers_attributes: [:id, :first_name, :last_name, :email, :gender, :birth_date, :city, :state])
   end
 
   def set_race_edition

--- a/app/controllers/race_editions_controller.rb
+++ b/app/controllers/race_editions_controller.rb
@@ -28,12 +28,15 @@ class RaceEditionsController < ApplicationController
   end
 
   def edit
+    @race_edition = RaceEdition.friendly.find(params[:id])
   end
 
   def update
     if @race_edition.update(obj_params)
       flash[:success] = "Your race edition was updated successfully"
       redirect_to race_edition_path(@race_edition)
+    else
+      render :edit
     end
   end
 

--- a/app/models/race_edition.rb
+++ b/app/models/race_edition.rb
@@ -16,4 +16,8 @@ class RaceEdition < ActiveRecord::Base
   def name
     "#{race&.name} on #{date}"
   end
+
+  def male_offset_minutes
+    male_offset / 60.0
+  end
 end

--- a/app/models/race_edition.rb
+++ b/app/models/race_edition.rb
@@ -24,7 +24,7 @@ class RaceEdition < ActiveRecord::Base
   def male_offset_minutes=(minutes)
     return unless minutes.present?
 
-    self.male_offset = minutes * 60
+    self.male_offset = minutes.to_f * 60
   end
 
   def female_offset_minutes
@@ -34,6 +34,6 @@ class RaceEdition < ActiveRecord::Base
   def female_offset_minutes=(minutes)
     return unless minutes.present?
 
-    self.female_offset = minutes * 60
+    self.female_offset = minutes.to_f * 60
   end
 end

--- a/app/models/race_edition.rb
+++ b/app/models/race_edition.rb
@@ -20,4 +20,10 @@ class RaceEdition < ActiveRecord::Base
   def male_offset_minutes
     male_offset / 60.0
   end
+
+  def male_offset_minutes=(minutes)
+    return unless minutes.present?
+
+    self.male_offset = minutes * 60
+  end
 end

--- a/app/models/race_edition.rb
+++ b/app/models/race_edition.rb
@@ -26,4 +26,14 @@ class RaceEdition < ActiveRecord::Base
 
     self.male_offset = minutes * 60
   end
+
+  def female_offset_minutes
+    female_offset / 60.0
+  end
+
+  def female_offset_minutes=(minutes)
+    return unless minutes.present?
+
+    self.female_offset = minutes * 60
+  end
 end

--- a/app/services/ost/translate_race_entry.rb
+++ b/app/services/ost/translate_race_entry.rb
@@ -19,12 +19,17 @@ module OST
     end
 
     def perform
-      {type: 'efforts', attributes: translate_attributes}
+      hash = {type: 'efforts', attributes: translate_attributes}
+      offset = racer.male? ? male_offset : female_offset
+      hash[:attributes][:scheduled_start_offset] = offset
+      hash
     end
 
     private
 
     attr_reader :race_entry
+    delegate :race_edition, :racer, to: :race_entry
+    delegate :male_offset, :female_offset, to: :race_edition
 
     def translate_attributes
       TRANSLATION_KEY.map { |ost_attribute, rr_attribute| [ost_attribute, race_entry_value(rr_attribute)] }.to_h

--- a/app/views/race_editions/_form.html.erb
+++ b/app/views/race_editions/_form.html.erb
@@ -17,11 +17,11 @@
       <%= f.label :entry_fee %>
       <%= f.text_field :entry_fee %>
 
-      <%= f.label :male_offset_minutes %>
-      <%= f.text_field 'Male start offset (minutes)' %>
+      <%= f.label 'Male start offset (minutes)' %>
+      <%= f.text_field :male_offset_minutes %>
 
-      <%= f.label :female_offset_minutes %>
-      <%= f.text_field 'Female start offset (minutes)' %>
+      <%= f.label 'Female start offset (minutes)' %>
+      <%= f.text_field :female_offset_minutes %>
 
       
       <%= f.submit(@race_edition.new_record? ? 'Create Race Edition' : 'Update Race Edition', class: "btn btn-success") %>

--- a/app/views/race_editions/_form.html.erb
+++ b/app/views/race_editions/_form.html.erb
@@ -5,6 +5,7 @@
     <%= form_for @race_edition do |f| %>
     
       <%= f.label :name %>
+      <%= f.text_field :name %>
 
       <%= f.label :date %>
       <%= datepicker_input(form: f,
@@ -15,6 +16,12 @@
                            
       <%= f.label :entry_fee %>
       <%= f.text_field :entry_fee %>
+
+      <%= f.label :male_offset_minutes %>
+      <%= f.text_field 'Male start offset (minutes)' %>
+
+      <%= f.label :female_offset_minutes %>
+      <%= f.text_field 'Female start offset (minutes)' %>
 
       
       <%= f.submit(@race_edition.new_record? ? 'Create Race Edition' : 'Update Race Edition', class: "btn btn-success") %>

--- a/app/views/race_editions/_form.html.erb
+++ b/app/views/race_editions/_form.html.erb
@@ -10,7 +10,7 @@
       <%= f.label :date %>
       <%= datepicker_input(form: f,
                            field: :date,
-                          # existing_date: :date,
+                           existing_date: @race_edition.date,
                            default_date: {year: 2019, month: 9, day: 14},
                            default_view: 'decades') %>
                            

--- a/db/migrate/20190913124555_add_offsets_to_race_editions.rb
+++ b/db/migrate/20190913124555_add_offsets_to_race_editions.rb
@@ -1,0 +1,6 @@
+class AddOffsetsToRaceEditions < ActiveRecord::Migration[5.1]
+  def change
+    add_column :race_editions, :male_offset, :integer, default: 0
+    add_column :race_editions, :female_offset, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170906210843) do
+ActiveRecord::Schema.define(version: 20190913124555) do
 
   create_table "product_images", force: :cascade do |t|
     t.integer "product_id", null: false
@@ -36,6 +36,8 @@ ActiveRecord::Schema.define(version: 20170906210843) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "slug"
+    t.integer "male_offset", default: 0
+    t.integer "female_offset", default: 0
     t.index ["race_id", "date"], name: "index_race_editions_on_race_id_and_date", unique: true
     t.index ["race_id"], name: "index_race_editions_on_race_id"
     t.index ["slug"], name: "index_race_editions_on_slug", unique: true

--- a/spec/models/race_edition_spec.rb
+++ b/spec/models/race_edition_spec.rb
@@ -32,4 +32,32 @@ RSpec.describe RaceEdition, type: :model do
       expect(race_edition.errors.full_messages).to include('Race has already been taken')
     end
   end
+
+  describe '#male_offset_minutes' do
+    subject { race_edition.male_offset_minutes }
+    let(:race_edition) { build_stubbed(:race_edition, male_offset: male_offset) }
+    let(:male_offset) { 0 }
+
+    context 'when male_offset is 0' do
+      it 'returns 0' do
+        expect(subject).to eq(0)
+      end
+    end
+
+    context 'when male_offset is a number of seconds divisible by 60' do
+      let(:male_offset) { 15 * 60 }
+      it 'returns the equivalent number of minutes as a float' do
+        expect(subject).to eq(15)
+        expect(subject).to be_a(Float)
+      end
+    end
+
+    context 'when male_offset is a number of seconds not divisible by 60' do
+      let(:male_offset) { 90 }
+      it 'returns the equivalent number of minutes as a float' do
+        expect(subject).to eq(1.5)
+        expect(subject).to be_a(Float)
+      end
+    end
+  end
 end

--- a/spec/models/race_edition_spec.rb
+++ b/spec/models/race_edition_spec.rb
@@ -60,4 +60,45 @@ RSpec.describe RaceEdition, type: :model do
       end
     end
   end
+
+  describe 'male_offset_minutes=' do
+    let(:race_edition) { build_stubbed(:race_edition, male_offset: existing_male_offset) }
+    before { race_edition.male_offset_minutes = male_offset_minutes }
+
+    context 'when existing offset is 0' do
+      let(:existing_male_offset) { 0 }
+
+      context 'when set to a positive value' do
+        let(:male_offset_minutes) { 15 }
+        it 'sets male_offset to the expected value' do
+          expect(race_edition.male_offset).to eq(15 * 60)
+        end
+      end
+
+      context 'when set to a negative value' do
+        let(:male_offset_minutes) { -15 }
+        it 'sets male_offset to the expected value' do
+          expect(race_edition.male_offset).to eq(-15 * 60)
+        end
+      end
+    end
+
+    context 'when existing offset is not 0' do
+      let(:existing_male_offset) { 900 }
+
+      context 'when set to a positive value' do
+        let(:male_offset_minutes) { 5 }
+        it 'sets male_offset to the expected value' do
+          expect(race_edition.male_offset).to eq(5 * 60)
+        end
+      end
+
+      context 'when set to a negative value' do
+        let(:male_offset_minutes) { -5 }
+        it 'sets male_offset to the expected value' do
+          expect(race_edition.male_offset).to eq(-5 * 60)
+        end
+      end
+    end
+  end
 end

--- a/spec/models/race_edition_spec.rb
+++ b/spec/models/race_edition_spec.rb
@@ -101,4 +101,45 @@ RSpec.describe RaceEdition, type: :model do
       end
     end
   end
+
+  describe 'female_offset_minutes=' do
+    let(:race_edition) { build_stubbed(:race_edition, female_offset: existing_female_offset) }
+    before { race_edition.female_offset_minutes = female_offset_minutes }
+
+    context 'when existing offset is 0' do
+      let(:existing_female_offset) { 0 }
+
+      context 'when set to a positive value' do
+        let(:female_offset_minutes) { 15 }
+        it 'sets female_offset to the expected value' do
+          expect(race_edition.female_offset).to eq(15 * 60)
+        end
+      end
+
+      context 'when set to a negative value' do
+        let(:female_offset_minutes) { -15 }
+        it 'sets female_offset to the expected value' do
+          expect(race_edition.female_offset).to eq(-15 * 60)
+        end
+      end
+    end
+
+    context 'when existing offset is not 0' do
+      let(:existing_female_offset) { 900 }
+
+      context 'when set to a positive value' do
+        let(:female_offset_minutes) { 5 }
+        it 'sets female_offset to the expected value' do
+          expect(race_edition.female_offset).to eq(5 * 60)
+        end
+      end
+
+      context 'when set to a negative value' do
+        let(:female_offset_minutes) { -5 }
+        it 'sets female_offset to the expected value' do
+          expect(race_edition.female_offset).to eq(-5 * 60)
+        end
+      end
+    end
+  end
 end

--- a/spec/services/ost/translate_race_entry_spec.rb
+++ b/spec/services/ost/translate_race_entry_spec.rb
@@ -2,15 +2,47 @@ require 'rails_helper'
 
 RSpec.describe OST::TranslateRaceEntry do
   describe '.perform' do
-    let(:racer) { build_stubbed(:racer, :male, first_name: 'Johnny', last_name: 'Appleseed', birth_date: '1999-10-01',
-                                city: 'Boulder', state: 'CO', email: 'johnny@appleseed.com') }
-    let(:race_entry) { build_stubbed(:race_entry, racer: racer, bib_number: 123) }
+    let(:race_entry) { build_stubbed(:race_entry, race_edition: race_edition, racer: racer, bib_number: 123) }
+    let(:race_edition) { build_stubbed(:race_edition, male_offset: male_offset, female_offset: female_offset) }
+    let(:male_offset) { 0 }
+    let(:female_offset) { 900 }
 
-    it 'translates a race_entry (with associated racer) into an OST-compatible attribute set' do
-      translation = OST::TranslateRaceEntry.perform(race_entry)
-      expect(translation).to eq(type: 'efforts',
-                                attributes: {gender: 'male', first_name: 'Johnny', last_name: 'Appleseed', birthdate: Date.parse('1999-10-01'),
-                                             city: 'Boulder', state_code: 'CO', email: 'johnny@appleseed.com', bib_number: 123})
+    context 'when the racer is male' do
+      let(:racer) { build_stubbed(:racer, :male, first_name: 'Johnny', last_name: 'Appleseed', birth_date: '1999-10-01',
+                                  city: 'Boulder', state: 'CO', email: 'johnny@appleseed.com') }
+
+      it 'translates a race_entry (with associated racer) into an OST-compatible attribute set with male offset' do
+        translation = OST::TranslateRaceEntry.perform(race_entry)
+        expect(translation).to eq(type: 'efforts',
+                                  attributes: { gender: 'male',
+                                                first_name: 'Johnny',
+                                                last_name: 'Appleseed',
+                                                birthdate: Date.parse('1999-10-01'),
+                                                city: 'Boulder',
+                                                state_code: 'CO',
+                                                email: 'johnny@appleseed.com',
+                                                bib_number: 123,
+                                                scheduled_start_offset: male_offset })
+      end
+    end
+
+    context 'when the racer is female' do
+      let(:racer) { build_stubbed(:racer, :female, first_name: 'Jane', last_name: 'Appleseed', birth_date: '1999-10-01',
+                                  city: 'Boulder', state: 'CO', email: 'johnny@appleseed.com') }
+
+      it 'translates a race_entry (with associated racer) into an OST-compatible attribute set with female offset' do
+        translation = OST::TranslateRaceEntry.perform(race_entry)
+        expect(translation).to eq(type: 'efforts',
+                                  attributes: { gender: 'female',
+                                                first_name: 'Jane',
+                                                last_name: 'Appleseed',
+                                                birthdate: Date.parse('1999-10-01'),
+                                                city: 'Boulder',
+                                                state_code: 'CO',
+                                                email: 'johnny@appleseed.com',
+                                                bib_number: 123,
+                                                scheduled_start_offset: female_offset })
+      end
     end
   end
 end


### PR DESCRIPTION
When exporting data to OST, there is currently not a way to set scheduled start times for male as opposed to female racers. 

This PR adds `male_offset` and `female_offset` attributes to the RaceEdition model, allowing the user to set an offset for male and female runners. The attributes default to 0.

For example, if the scheduled race will have men starting at 7:45 and women at 8:00, we would create the event and add a 15-minute female offset. When racers are imported into OST, start times will then be accurately reflected.