### PR TITLE
Add Procfile to run migrations on deploys

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+web: bundle exec puma -C config/puma.rb
+release: rake db:migrate


### PR DESCRIPTION
Currently, when code is deployed to Heroku, we have to remember to run migrations or we end up with errors in production. 

This MR creates a basic Procfile that specifies Puma server settings (pointing to the existing `config/puma.rb`) and adds `rake db:migrate` to the release phase.

Heroku Procfile information can be found here: https://devcenter.heroku.com/articles/procfile

Information about the Heroku Release Phase is here: https://devcenter.heroku.com/articles/release-phase