### PR TITLE
Fix the Race Editions form

### DIFF
--- a/app/controllers/race_editions_controller.rb
+++ b/app/controllers/race_editions_controller.rb
@@ -9,7 +9,7 @@ class RaceEditionsController < ApplicationController
   end
 
   def new
-    @race_edition = RaceEdition.new
+    @race_edition = RaceEdition.new(obj_params)
   end
 
   def create

--- a/app/controllers/race_editions_controller.rb
+++ b/app/controllers/race_editions_controller.rb
@@ -24,7 +24,6 @@ class RaceEditionsController < ApplicationController
   end
 
   def edit
-    @race_edition = RaceEdition.friendly.find(params[:id])
   end
 
   def update

--- a/app/controllers/race_editions_controller.rb
+++ b/app/controllers/race_editions_controller.rb
@@ -90,7 +90,7 @@ class RaceEditionsController < ApplicationController
 
   def obj_params
     params.require(:race_edition)
-        .permit(:date, :male_offset_minutes, :female_offset_minutes,
+        .permit(:race_id, :date, :entry_fee, :male_offset_minutes, :female_offset_minutes,
                 racers_attributes: [:id, :first_name, :last_name, :email, :gender, :birth_date, :city, :state])
   end
 

--- a/app/controllers/race_editions_controller.rb
+++ b/app/controllers/race_editions_controller.rb
@@ -35,6 +35,13 @@ class RaceEditionsController < ApplicationController
     end
   end
 
+  def destroy
+    if @race_edition.destroy
+      flash[:success] = "Your race edition was deleted"
+      redirect_to races_path
+    end
+  end
+
   def enter
     @racer = Racer.new
   end

--- a/app/controllers/race_editions_controller.rb
+++ b/app/controllers/race_editions_controller.rb
@@ -17,7 +17,7 @@ class RaceEditionsController < ApplicationController
 
     if @race_edition.save
       flash[:success] = "Your race edition was created successfully!"
-      redirect_to race_editions_path
+      redirect_to race_edition_path(@race_edition)
     else
       render :new
     end

--- a/app/views/race_editions/_form.html.erb
+++ b/app/views/race_editions/_form.html.erb
@@ -19,8 +19,10 @@
       <%= f.label 'Female start offset (minutes)' %>
       <%= f.text_field :female_offset_minutes %>
 
-      
+      <hr/>
       <%= f.submit(@race_edition.new_record? ? 'Create Race Edition' : 'Update Race Edition', class: "btn btn-success") %>
+      <hr/>
+      <%= link_to '[ Cancel ]', @race_edition.new_record? ? races_path : race_edition_path(@race_edition) %>
     <% end %>
   </div>
 </div>

--- a/app/views/race_editions/_form.html.erb
+++ b/app/views/race_editions/_form.html.erb
@@ -26,6 +26,9 @@
       <hr/>
       <%= f.submit(@race_edition.new_record? ? 'Create Race Edition' : 'Update Race Edition', class: "btn btn-success") %>
       <hr/>
+      <% unless @race_edition.new_record? %>
+        <%= link_to 'Delete Race Edition', race_edition_path(@race_edition), method: :delete, data: {confirm: 'Delete this race edition?'}, class: 'btn btn-danger btn-block' %>
+      <% end %>
       <%= link_to '[ Cancel ]', @race_edition.new_record? ? races_path : race_edition_path(@race_edition) %>
     <% end %>
   </div>

--- a/app/views/race_editions/_form.html.erb
+++ b/app/views/race_editions/_form.html.erb
@@ -3,6 +3,10 @@
 <div class="row">
   <div class="well col-md-8 col-md-offset-2">
     <%= form_for @race_edition do |f| %>
+      <%= f.label :race %>
+      <%= f.select :race_id, Race.all.map { |race| [race.name, race.id] },
+                   {prompt: true}, {class: "form-control dropdown-select-field"} %>
+
       <%= f.label :date %>
       <%= datepicker_input(form: f,
                            field: :date,

--- a/app/views/race_editions/_form.html.erb
+++ b/app/views/race_editions/_form.html.erb
@@ -3,10 +3,6 @@
 <div class="row">
   <div class="well col-md-8 col-md-offset-2">
     <%= form_for @race_edition do |f| %>
-    
-      <%= f.label :name %>
-      <%= f.text_field :name %>
-
       <%= f.label :date %>
       <%= datepicker_input(form: f,
                            field: :date,

--- a/app/views/race_editions/edit.html.erb
+++ b/app/views/race_editions/edit.html.erb
@@ -1,3 +1,4 @@
 <%= render 'shared/page_title', title: "Edit Race Edition" %>
+<h3><%= @race_edition.name %></h3>
 
 <%= render 'form' %>

--- a/app/views/races/show.html.erb
+++ b/app/views/races/show.html.erb
@@ -1,7 +1,7 @@
 <%= render 'shared/page_title', title: @race.name %>
 
 <div class="col-md-12 pull-right new-model-button">
-  <%= link_to "New Race Edition", new_race_edition_path, class: "btn btn-success pull-left" %>
+  <%= link_to "New Race Edition", new_race_edition_path(race_edition: {race_id: @race.id}), class: "btn btn-success pull-left" %>
 </div>
 
 <div class="row">


### PR DESCRIPTION
Currently, the race edition form is misleading because it contains a "Name" field. A race edition name is not a persisted attribute and cannot be changed. It is a computed field built from the associated race and the date of the race edition. 

The form was always a bit confusing because it included "name" as a label in the form. https://github.com/billwright/rattlesnake_ramble/pull/45 made matters worse by including a "name" field to match the label. This PR corrects the problem by removing "name" entirely from the race editions form and putting it in the title of the race_editions/edit view.

Also, a new race edition cannot be created through the forms because some required parameters are not permitted params in the race editions controller. Also, when a new race edition form is accessed from a race show view, the race id is not passed to the race editions form.

The PR makes several small changes to the Race Editions form and controller, allowing a more natural flow when creating and editing race editions.
