### PR TITLE
Migration to add scheduled_start_time to race_entries table

### DIFF
--- a/db/migrate/20200904043442_add_scheduled_start_time_to_race_entries.rb
+++ b/db/migrate/20200904043442_add_scheduled_start_time_to_race_entries.rb
@@ -1,0 +1,5 @@
+class AddScheduledStartTimeToRaceEntries < ActiveRecord::Migration[5.1]
+  def change
+    add_column :race_entries, :scheduled_start_time, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190913124555) do
+ActiveRecord::Schema.define(version: 20200904043442) do
 
   create_table "product_images", force: :cascade do |t|
     t.integer "product_id", null: false
@@ -51,6 +51,7 @@ ActiveRecord::Schema.define(version: 20190913124555) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "bib_number"
+    t.datetime "scheduled_start_time"
     t.index ["race_edition_id"], name: "index_race_entries_on_race_edition_id"
     t.index ["racer_id"], name: "index_race_entries_on_racer_id"
   end


### PR DESCRIPTION
Database migration to add the `scheduled_start_times` column to the `race_entries` table.

Addresses a portion of #64