### PR TITLE
Make expected URL more flexible in post entries spec

### DIFF
--- a/spec/services/ost/post_entries_spec.rb
+++ b/spec/services/ost/post_entries_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe OST::PostEntries do
     it 'sends a properly constructed URL to RestClient' do
       allow(RestClient).to receive(:post)
       OST::PostEntries.perform(race_edition: race_edition, ost_event_id: 'test-event', token: token)
-      expected_url = 'https://ost-stage.herokuapp.com/api/v1/events/test-event/import'
+      expected_url = "#{ENV['OST_URL']}/api/v1/events/test-event/import"
       expect(RestClient).to have_received(:post).with(expected_url, anything, anything)
     end
 


### PR DESCRIPTION
We have a spec that fails depending on the setting of an environment variable. This PR makes the spec less fragile.