### PR TITLE
Move environment variables to config and properly stub specs

### DIFF
--- a/app/services/ost/get_token.rb
+++ b/app/services/ost/get_token.rb
@@ -1,9 +1,9 @@
 module OST
   class GetToken
     def self.perform
-      full_url = "#{ENV['OST_URL']}#{OST::Constants::AUTH_ENDPOINT}"
-      response = RestClient.post(full_url, {user: {email: ENV['OST_EMAIL'],
-                                                   password: ENV['OST_PASSWORD']}})
+      full_url = "#{RambleConfig.ost_url}#{OST::Constants::AUTH_ENDPOINT}"
+      response = RestClient.post(full_url, {user: {email: RambleConfig.ost_email,
+                                                   password: RambleConfig.ost_password}})
       OST::Response.new(response)
 
     rescue RestClient::ExceptionWithResponse => e

--- a/app/services/ost/post_entries.rb
+++ b/app/services/ost/post_entries.rb
@@ -22,7 +22,7 @@ module OST
     attr_reader :race_edition, :ost_event_id, :token
 
     def import_url
-      ENV['OST_URL'] + import_endpoint
+      "#{RambleConfig.ost_url}#{import_endpoint}"
     end
 
     def import_endpoint

--- a/config/initializers/01_ramble_config.rb
+++ b/config/initializers/01_ramble_config.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module RambleConfig
+  def self.ost_email
+    ENV["OST_EMAIL"]
+  end
+
+  def self.ost_password
+    ENV["OST_PASSWORD"]
+  end
+
+  def self.ost_url
+    ENV["OST_URL"].presence || "https://www.opensplittime.org"
+  end
+end

--- a/spec/services/ost/get_token_spec.rb
+++ b/spec/services/ost/get_token_spec.rb
@@ -3,10 +3,22 @@ require 'rails_helper'
 RSpec.describe OST::GetToken do
   describe '.perform' do
     let(:response) { OST::GetToken.perform }
+    let(:example_email) { "ramble@example.com" }
+    let(:example_password) { "password" }
+
+    let(:expected_payload) do
+      { user: { email: example_email, password: example_password } }
+    end
+
+    before do
+      allow(RestClient).to receive(:post)
+      allow(RambleConfig).to receive(:ost_email).and_return(example_email)
+      allow(RambleConfig).to receive(:ost_password).and_return(example_password)
+    end
 
     it 'returns an OST::Response containing a JSON Web Token' do
-      expect(response.token).to be_present
-      expect(response.token.split('.').size).to eq(3)
+      expect(RestClient).to receive(:post).with("https://www.opensplittime.org/api/v1/auth", expected_payload)
+      response
     end
   end
 end

--- a/spec/services/ost/post_entries_spec.rb
+++ b/spec/services/ost/post_entries_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe OST::PostEntries do
     it 'sends a properly constructed URL to RestClient' do
       allow(RestClient).to receive(:post)
       OST::PostEntries.perform(race_edition: race_edition, ost_event_id: 'test-event', token: token)
-      expected_url = 'https://ost-stage.herokuapp.com/api/v1/events/test-event/import'
+      expected_url = 'https://www.opensplittime.org/api/v1/events/test-event/import'
       expect(RestClient).to have_received(:post).with(expected_url, anything, anything)
     end
 


### PR DESCRIPTION
This should fix tests that are failing as a result of having incomplete environment variables, including in the GitLab CI pipeline.

First step in addressing #70