### PR TITLE
Race Edition default start times

### DIFF
--- a/app/controllers/race_editions_controller.rb
+++ b/app/controllers/race_editions_controller.rb
@@ -97,7 +97,7 @@ class RaceEditionsController < ApplicationController
 
   def obj_params
     params.require(:race_edition)
-        .permit(:race_id, :date, :entry_fee, :male_offset_minutes, :female_offset_minutes,
+        .permit(:race_id, :date, :entry_fee, :default_start_time_male_local, :default_start_time_female_local,
                 racers_attributes: [:id, :first_name, :last_name, :email, :gender, :birth_date, :city, :state])
   end
 

--- a/app/models/concerns/time_zonable.rb
+++ b/app/models/concerns/time_zonable.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+# Used for models with one or more datetime attributes
+# that need to be localized to `home_time_zone`.
+# Also sets a default date when an object of the including
+# class responds to `date`.
+#
+module TimeZonable
+  def self.included(klass)
+    klass.extend(ClassMethods)
+  end
+
+  module ClassMethods
+    def zonable_attributes(*attributes)
+      attributes.each(&method(:zonable_attribute))
+    end
+
+    def zonable_attribute(attribute)
+      define_method :"#{attribute}_local" do
+        unless time_zone_valid?(home_time_zone)
+          return nil
+        end
+        send(attribute)&.in_time_zone(home_time_zone)
+      end
+
+      define_method :"#{attribute}_local=" do |datetime_or_time|
+        if datetime_or_time.present?
+          unless time_zone_valid?(home_time_zone)
+            raise ArgumentError, "#{attribute}_local cannot be set without a valid home_time_zone"
+          end
+          local_string = if datetime_or_time =~ ::RambleConfig.military_time_regex and respond_to?(:date)
+                           "#{date.to_s} #{datetime_or_time}"
+                         else
+                           datetime_or_time.to_s
+                         end
+          self.send("#{attribute}=", local_string.in_time_zone(home_time_zone))
+        else
+          self.send("#{attribute}=", nil)
+        end
+      end
+    end
+  end
+
+  def time_zone_valid?(time_zone_string)
+    time_zone_string.present? && ActiveSupport::TimeZone[time_zone_string].present?
+  end
+end

--- a/app/models/race_edition.rb
+++ b/app/models/race_edition.rb
@@ -1,9 +1,12 @@
 class RaceEdition < ActiveRecord::Base
   extend FriendlyId
+  include TimeZonable
 
   belongs_to :race
   has_many :race_entries, dependent: :destroy
   has_many :racers, through: :race_entries
+
+  zonable_attributes :default_start_time_female, :default_start_time_male
 
   accepts_nested_attributes_for :racers
   friendly_id :name, use: :slugged
@@ -15,5 +18,9 @@ class RaceEdition < ActiveRecord::Base
 
   def name
     "#{race&.name} on #{date}"
+  end
+
+  def home_time_zone
+    ::RambleConfig.home_time_zone
   end
 end

--- a/app/views/race_editions/_form.html.erb
+++ b/app/views/race_editions/_form.html.erb
@@ -17,11 +17,11 @@
       <%= f.label :entry_fee %>
       <%= f.text_field :entry_fee %>
 
-      <%= f.label 'Male start offset (minutes)' %>
-      <%= f.text_field :male_offset_minutes %>
+      <%= f.label 'Male default start time' %>
+      <%= f.text_field :default_start_time_male_local, placeholder: 'hh:mm:ss' %>
 
-      <%= f.label 'Female start offset (minutes)' %>
-      <%= f.text_field :female_offset_minutes %>
+      <%= f.label 'Female default start time' %>
+      <%= f.text_field :default_start_time_female_local, placeholder: 'hh:mm:ss' %>
 
       <hr/>
       <%= f.submit(@race_edition.new_record? ? 'Create Race Edition' : 'Update Race Edition', class: "btn btn-success") %>

--- a/config/initializers/01_ramble_config.rb
+++ b/config/initializers/01_ramble_config.rb
@@ -1,6 +1,14 @@
 # frozen_string_literal: true
 
 module RambleConfig
+  def self.home_time_zone
+    "Mountain Time (US & Canada)"
+  end
+
+  def self.military_time_regex
+    /\A\d{1,2}:\d{2}(:\d{2})?\z/
+  end
+
   def self.ost_email
     ENV["OST_EMAIL"]
   end

--- a/spec/models/race_edition_spec.rb
+++ b/spec/models/race_edition_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 # t.date "date"
@@ -30,6 +32,43 @@ RSpec.describe RaceEdition, type: :model do
       race_edition = build_stubbed(:race_edition, race: existing_race_edition.race, date: existing_race_edition.date)
       expect(race_edition).to be_invalid
       expect(race_edition.errors.full_messages).to include('Race has already been taken')
+    end
+  end
+
+  describe '#default_start_time_female_local= and #default_start_time_male_local=' do
+    subject do
+      build_stubbed(:race_edition,
+                    date: date,
+                    default_start_time_female_local: default_start_time_female_local,
+                    default_start_time_male_local: default_start_time_male_local)
+    end
+    let(:date) { '2020-09-12'.to_date }
+
+    context 'when given nil' do
+      let(:default_start_time_female_local) { nil }
+      let(:default_start_time_male_local) { nil }
+      it 'sets the underlying attributes to nil' do
+        expect(subject.default_start_time_female).to be_nil
+        expect(subject.default_start_time_male).to be_nil
+      end
+    end
+
+    context 'when given a time string without a time zone' do
+      let(:default_start_time_female_local) { '2020-09-12 7:45:00' }
+      let(:default_start_time_male_local) { '2020-09-12 7:30:00' }
+      it 'sets the underlying attributes using home time zone' do
+        expect(subject.default_start_time_female).to eq('2020-09-12 07:45:00-0600'.to_datetime)
+        expect(subject.default_start_time_male).to eq('2020-09-12 07:30:00-0600'.to_datetime)
+      end
+    end
+
+    context 'when given a military time string' do
+      let(:default_start_time_female_local) { '7:45:00' }
+      let(:default_start_time_male_local) { '7:30:00' }
+      it 'sets the underlying attributes using date and home time zone' do
+        expect(subject.default_start_time_female).to eq('2020-09-12 07:45:00-0600'.to_datetime)
+        expect(subject.default_start_time_male).to eq('2020-09-12 07:30:00-0600'.to_datetime)
+      end
     end
   end
 end


### PR DESCRIPTION
Introduces a `TimeZonable` module, which provides `_local` extensions to specified attributes. Using the `_local` extensions, this module converts time strings into the home time zone for the including class and uses a default date if provided by the including class. 

Makes the Race Edition `default_start_time_female` and `default_start_time_male` attributes zonable.

Provides a UI for setting default start times for those attributes.

Addresses a portion of #64