### PR TITLE
Remove index from users table

### DIFF
--- a/db/migrate/20200906161043_devise_create_users.rb
+++ b/db/migrate/20200906161043_devise_create_users.rb
@@ -9,7 +9,6 @@ class DeviseCreateUsers < ActiveRecord::Migration[5.1]
       t.timestamps null: false
     end
 
-    add_index :users, :email,                unique: true
-    add_index :users, :reset_password_token, unique: true
+    add_index :users, :email, unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -85,7 +85,6 @@ ActiveRecord::Schema.define(version: 20200906200341) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
-    t.index [nil], name: "index_users_on_reset_password_token", unique: true
   end
 
 end


### PR DESCRIPTION
Fixes a faulty migration. It should be OK to edit this migration directly, because it hasn't been run in production.