### PR TITLE
Remove default gender from Racers

### DIFF
--- a/app/views/race_editions/enter.html.erb
+++ b/app/views/race_editions/enter.html.erb
@@ -6,7 +6,7 @@
 
     <%= race_edition_form.fields_for :racers, @racer do |racer_fields| %>
       <%= racer_fields.label :first_name %>
-      <%= racer_fields.text_field :first_name %>
+      <%= racer_fields.text_field :first_name, autofocus: true %>
     
       <%= racer_fields.label :last_name %>
       <%= racer_fields.text_field :last_name %>
@@ -15,7 +15,7 @@
       <%= racer_fields.text_field :email %>
     
       <%= racer_fields.label :gender %>
-      <%= racer_fields.select :gender, Racer.genders.keys, {} %>
+      <%= racer_fields.select :gender, Racer.genders.keys, include_blank: true %>
     
       <%= racer_fields.label :birth_date %>
       <%= datepicker_input(form: racer_fields,

--- a/app/views/race_entries/_entries.html.erb
+++ b/app/views/race_entries/_entries.html.erb
@@ -1,6 +1,7 @@
 <table class="table">
   <tr>
     <th><%= link_to 'Racer', request.params.merge(sort: 'racers.last_name') %></th>
+    <th><%= link_to 'Gender', request.params.merge(sort: 'racers.gender,racers.birth_date desc') %></th>
     <th><%= link_to 'Age', request.params.merge(sort: 'racers.birth_date desc') %></th>
     <th><%= link_to 'Bib #', request.params.merge(sort: 'bib_number') %></th>
     <th><%= link_to 'Start Time', request.params.merge(sort: 'race_entries.scheduled_start_time,race_entries.bib_number') %></th>
@@ -11,6 +12,7 @@
   <% race_entries.each do |race_entry| %>
     <tr>
       <td><%= link_to race_entry.racer.name, edit_race_entry_path(race_entry)  %></td>
+      <td><%= race_entry.racer.gender.titleize %></td>
       <td><%= race_entry.racer.current_age %></td>
       <td><%= race_entry.bib_number %></td>
       <td><%= race_entry.scheduled_start_time_military %></td>

--- a/db/migrate/20200913140801_remove_default_from_racer_gender.rb
+++ b/db/migrate/20200913140801_remove_default_from_racer_gender.rb
@@ -1,0 +1,5 @@
+class RemoveDefaultFromRacerGender < ActiveRecord::Migration[5.1]
+  def change
+    change_column_default :racers, :gender, from: 0, to: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200906200341) do
+ActiveRecord::Schema.define(version: 20200913140801) do
 
   create_table "product_images", force: :cascade do |t|
     t.integer "product_id", null: false
@@ -59,7 +59,7 @@ ActiveRecord::Schema.define(version: 20200906200341) do
   create_table "racers", force: :cascade do |t|
     t.string "first_name", null: false
     t.string "last_name", null: false
-    t.integer "gender", default: 0
+    t.integer "gender"
     t.string "email", null: false
     t.string "city"
     t.string "state"


### PR DESCRIPTION
We had a couple of instances of women entering themselves as men because the gender is set to Male by default. 

This PR proposes to remove the default and require an entrant to pick a gender from the dropdown menu, reducing the chances of this problem happening in the future.