### PR TITLE
SQLite boolean fix

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -37,6 +37,9 @@ Rails.application.configure do
   # Raise an error on page load if there are pending migrations.
   config.active_record.migration_error = :page_load
 
+  # Store sqlite booleans as integers
+  config.active_record.sqlite3.represent_boolean_as_integer = true
+
   # Debug mode disables concatenation and preprocessing of assets.
   # This option may cause significant delays in view rendering with a large
   # number of complex assets.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -37,6 +37,9 @@ Rails.application.configure do
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 
+  # Store sqlite booleans as integers
+  config.active_record.sqlite3.represent_boolean_as_integer = true
+
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,7 +6,7 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-races = Race.create([
+races = Race.create!([
     { name: "Rattlesnake Ramble Trail Race", description: "A 4.25-mile Y-course that goes out-and-back on the Fowler Trail before doing the same on the Eldorado Trail." },
     { name: "Rattlesnake Ramble Trail Race Even-Year", description: "A 4.25-mile Y-course that goes out-and-back on the Eldorado Trail before doing the same on the Fowler Trail." },
     { name: "Rattlesnake Ramble Kids Race", description: "A 1.7-mile out-and-back course on the main road through Eldorado Canyon. The Kids Race is for 12 & Under only." },
@@ -15,20 +15,20 @@ races = Race.create([
 current_race = races.first
 kids_race = races.last
 
-current_edition = RaceEdition.create(race: current_race, date: "2017-09-09", entry_fee: 25)
-kids_edition = RaceEdition.create(race: kids_race, date: "2017-09-09", entry_fee: 10)
+current_edition = RaceEdition.create!(race: current_race, date: "2017-09-09", entry_fee: 25)
+kids_edition = RaceEdition.create!(race: kids_race, date: "2017-09-09", entry_fee: 10)
 
-racer_bill = Racer.create(first_name: "Bill", last_name: "Wright", email: "bill@wwwright.com", gender: :male, birth_date: "1962-04-26", city: "Superior", state: "Colorado")
-racer_sheri = Racer.create(first_name: "Sheri", last_name: "Wright", email: "sheri_wright@oracle.com", gender: :female, birth_date: "1963-12-18", city: "Superior", state: "Colorado")
-racer_derek = Racer.create(first_name: "Derek", last_name: "Wright", email: "poochito@gmail.com", gender: :male, birth_date: "1998-01-29", city: "Superior", state: "Colorado")
-racer_jason = Racer.create(first_name: "Jason", last_name: "Oveson", email: "jason@example.com", gender: :male, birth_date: "2014-01-01", city: "Louisville", state: "Colorado")
-racer_spencer = Racer.create(first_name: "Spencer", last_name: "Oveson", email: "spencer@example.com", gender: :male, birth_date: "2014-01-01", city: "Louisville", state: "Colorado")
+racer_bill = Racer.create!(first_name: "Bill", last_name: "Wright", email: "bill@wwwright.com", gender: :male, birth_date: "1962-04-26", city: "Superior", state: "Colorado")
+racer_sheri = Racer.create!(first_name: "Sheri", last_name: "Wright", email: "sheri_wright@oracle.com", gender: :female, birth_date: "1963-12-18", city: "Superior", state: "Colorado")
+racer_derek = Racer.create!(first_name: "Derek", last_name: "Wright", email: "poochito@gmail.com", gender: :male, birth_date: "1998-01-29", city: "Superior", state: "Colorado")
+racer_jason = Racer.create!(first_name: "Jason", last_name: "Oveson", email: "jason@example.com", gender: :male, birth_date: "2014-01-01", city: "Louisville", state: "Colorado")
+racer_spencer = Racer.create!(first_name: "Spencer", last_name: "Oveson", email: "spencer@example.com", gender: :male, birth_date: "2014-01-01", city: "Louisville", state: "Colorado")
 
-RaceEntry.create(racer: racer_bill, race_edition: current_edition, bib_number: 123, paid: true)
-RaceEntry.create(racer: racer_sheri, race_edition: current_edition, bib_number: 234, paid: true)
-RaceEntry.create(racer: racer_derek, race_edition: current_edition, paid: false)
-RaceEntry.create(racer: racer_jason, race_edition: kids_edition, bib_number: 3, paid: true)
-RaceEntry.create(racer: racer_spencer, race_edition: kids_edition, paid: false)
+RaceEntry.create!(racer: racer_bill, race_edition: current_edition, bib_number: 123, paid: true)
+RaceEntry.create!(racer: racer_sheri, race_edition: current_edition, bib_number: 234, paid: true)
+RaceEntry.create!(racer: racer_derek, race_edition: current_edition, paid: false)
+RaceEntry.create!(racer: racer_jason, race_edition: kids_edition, bib_number: 3, paid: true)
+RaceEntry.create!(racer: racer_spencer, race_edition: kids_edition, paid: false)
 
 
 # 2017 Merchandise
@@ -37,47 +37,47 @@ Product.all.each do |prod|
     prod.destroy
 end
 
-prod = Product.create(description: "Men's Cotton 2017 Race Shirt, size medium", quantity: 10, price: 25)
-ProductImage.create(product: prod, url: 'RR2017MensShirtFront.png', alt_text: "Men's Race Shirt Front")
-prod = Product.create(description: "Men's Cotton 2017 Race Shirt, size large", quantity: 10, price: 25)
-ProductImage.create(product: prod, url: 'RR2017MensShirtFront.png', alt_text: "Men's Race Shirt Front")
-prod = Product.create(description: "Men's Cotton 2017 Race Shirt, size extra-large", quantity: 3, price: 25)
-ProductImage.create(product: prod, url: 'RR2017MensShirtFront.png', alt_text: "Men's Race Shirt Front")
+prod = Product.create!(description: "Men's Cotton 2017 Race Shirt, size medium", quantity: 10, price: 25)
+ProductImage.create!(product: prod, url: 'RR2017MensShirtFront.png', alt_text: "Men's Race Shirt Front")
+prod = Product.create!(description: "Men's Cotton 2017 Race Shirt, size large", quantity: 10, price: 25)
+ProductImage.create!(product: prod, url: 'RR2017MensShirtFront.png', alt_text: "Men's Race Shirt Front")
+prod = Product.create!(description: "Men's Cotton 2017 Race Shirt, size extra-large", quantity: 3, price: 25)
+ProductImage.create!(product: prod, url: 'RR2017MensShirtFront.png', alt_text: "Men's Race Shirt Front")
 
-prod = Product.create(description: "Women's Cotton 2017 Race Shirt, size small", quantity: 10, price: 25)
-ProductImage.create(product: prod, url: 'RR2017WomensShirtFront.png', alt_text: "Women's Race Shirt Front")
-ProductImage.create(product: prod, url: 'RR2017WomensShirtBack.png', alt_text: "Women's Race Shirt Back")
-prod = Product.create(description: "Women's Cotton 2017 Race Shirt, size medium", quantity: 10, price: 25)
-ProductImage.create(product: prod, url: 'RR2017WomensShirtFront.png', alt_text: "Women's Race Shirt Front")
-ProductImage.create(product: prod, url: 'RR2017WomensShirtBack.png', alt_text: "Women's Race Shirt Back")
-prod = Product.create(description: "Women's Cotton 2017 Race Shirt, size large", quantity: 5, price: 25)
-ProductImage.create(product: prod, url: 'RR2017WomensShirtFront.png', alt_text: "Women's Race Shirt Front")
-ProductImage.create(product: prod, url: 'RR2017WomensShirtBack.png', alt_text: "Women's Race Shirt Back")
+prod = Product.create!(description: "Women's Cotton 2017 Race Shirt, size small", quantity: 10, price: 25)
+ProductImage.create!(product: prod, url: 'RR2017WomensShirtFront.png', alt_text: "Women's Race Shirt Front")
+ProductImage.create!(product: prod, url: 'RR2017WomensShirtBack.png', alt_text: "Women's Race Shirt Back")
+prod = Product.create!(description: "Women's Cotton 2017 Race Shirt, size medium", quantity: 10, price: 25)
+ProductImage.create!(product: prod, url: 'RR2017WomensShirtFront.png', alt_text: "Women's Race Shirt Front")
+ProductImage.create!(product: prod, url: 'RR2017WomensShirtBack.png', alt_text: "Women's Race Shirt Back")
+prod = Product.create!(description: "Women's Cotton 2017 Race Shirt, size large", quantity: 5, price: 25)
+ProductImage.create!(product: prod, url: 'RR2017WomensShirtFront.png', alt_text: "Women's Race Shirt Front")
+ProductImage.create!(product: prod, url: 'RR2017WomensShirtBack.png', alt_text: "Women's Race Shirt Back")
 
-prod = Product.create(description: "Men's Cotton 2017 Race Shirt, size medium", quantity: 10, price: 25)
-ProductImage.create(product: prod, url: 'RRMainLogoMensShirtFront.png', alt_text: "Men's Race Shirt Front")
-prod = Product.create(description: "Men's Cotton 2017 Race Shirt, size large", quantity: 10, price: 25)
-ProductImage.create(product: prod, url: 'RRMainLogoMensShirtFront.png', alt_text: "Men's Race Shirt Front")
-prod = Product.create(description: "Men's Cotton 2017 Race Shirt, size extra-large", quantity: 3, price: 25)
-ProductImage.create(product: prod, url: 'RRMainLogoMensShirtFront.png', alt_text: "Men's Race Shirt Front")
+prod = Product.create!(description: "Men's Cotton 2017 Race Shirt, size medium", quantity: 10, price: 25)
+ProductImage.create!(product: prod, url: 'RRMainLogoMensShirtFront.png', alt_text: "Men's Race Shirt Front")
+prod = Product.create!(description: "Men's Cotton 2017 Race Shirt, size large", quantity: 10, price: 25)
+ProductImage.create!(product: prod, url: 'RRMainLogoMensShirtFront.png', alt_text: "Men's Race Shirt Front")
+prod = Product.create!(description: "Men's Cotton 2017 Race Shirt, size extra-large", quantity: 3, price: 25)
+ProductImage.create!(product: prod, url: 'RRMainLogoMensShirtFront.png', alt_text: "Men's Race Shirt Front")
 
-prod = Product.create(description: "Women's Rattlesnake Ramble Shirt, size small", quantity: 10, price: 25)
-ProductImage.create(product: prod, url: 'RRMainLogoWomensShirtFront.png', alt_text: "Women's Race Shirt Front")
-ProductImage.create(product: prod, url: 'RRMainLogoWomensShirtBack.png', alt_text: "Women's Race Shirt Back")
-prod = Product.create(description: "Women's Rattlesnake Ramble Shirt, size medium", quantity: 10, price: 25)
-ProductImage.create(product: prod, url: 'RRMainLogoWomensShirtFront.png', alt_text: "Women's Race Shirt Front")
-ProductImage.create(product: prod, url: 'RRMainLogoWomensShirtBack.png', alt_text: "Women's Race Shirt Back")
-prod = Product.create(description: "Women's Rattlesnake Ramble Shirt, size large", quantity: 3, price: 25)
-ProductImage.create(product: prod, url: 'RRMainLogoWomensShirtFront.png', alt_text: "Women's Race Shirt Front")
-ProductImage.create(product: prod, url: 'RRMainLogoWomensShirtBack.png', alt_text: "Women's Race Shirt Back")
+prod = Product.create!(description: "Women's Rattlesnake Ramble Shirt, size small", quantity: 10, price: 25)
+ProductImage.create!(product: prod, url: 'RRMainLogoWomensShirtFront.png', alt_text: "Women's Race Shirt Front")
+ProductImage.create!(product: prod, url: 'RRMainLogoWomensShirtBack.png', alt_text: "Women's Race Shirt Back")
+prod = Product.create!(description: "Women's Rattlesnake Ramble Shirt, size medium", quantity: 10, price: 25)
+ProductImage.create!(product: prod, url: 'RRMainLogoWomensShirtFront.png', alt_text: "Women's Race Shirt Front")
+ProductImage.create!(product: prod, url: 'RRMainLogoWomensShirtBack.png', alt_text: "Women's Race Shirt Back")
+prod = Product.create!(description: "Women's Rattlesnake Ramble Shirt, size large", quantity: 3, price: 25)
+ProductImage.create!(product: prod, url: 'RRMainLogoWomensShirtFront.png', alt_text: "Women's Race Shirt Front")
+ProductImage.create!(product: prod, url: 'RRMainLogoWomensShirtBack.png', alt_text: "Women's Race Shirt Back")
 
-prod = Product.create(description: "Black, Cotton, Hooded, Uni-Sex Sweatshirt, size small", quantity: 5, price: 40)
-ProductImage.create(product: prod, url: 'RattlesnakeRambleHoodie.png', alt_text: "Sweatshirt Front")
-prod = Product.create(description: "Black, Cotton, Hooded, Uni-Sex Sweatshirt, size medium", quantity: 5, price: 40)
-ProductImage.create(product: prod, url: 'RattlesnakeRambleHoodie.png', alt_text: "Sweatshirt Front")
-prod = Product.create(description: "Black, Cotton, Hooded, Uni-Sex Sweatshirt, size large", quantity: 5, price: 40)
-ProductImage.create(product: prod, url: 'RattlesnakeRambleHoodie.png', alt_text: "Sweatshirt Front")
-prod = Product.create(description: "Black, Cotton, Hooded, Uni-Sex Sweatshirt, size extra-large", quantity: 3, price: 40)
-ProductImage.create(product: prod, url: 'RattlesnakeRambleHoodie.png', alt_text: "Sweatshirt Front")
+prod = Product.create!(description: "Black, Cotton, Hooded, Uni-Sex Sweatshirt, size small", quantity: 5, price: 40)
+ProductImage.create!(product: prod, url: 'RattlesnakeRambleHoodie.png', alt_text: "Sweatshirt Front")
+prod = Product.create!(description: "Black, Cotton, Hooded, Uni-Sex Sweatshirt, size medium", quantity: 5, price: 40)
+ProductImage.create!(product: prod, url: 'RattlesnakeRambleHoodie.png', alt_text: "Sweatshirt Front")
+prod = Product.create!(description: "Black, Cotton, Hooded, Uni-Sex Sweatshirt, size large", quantity: 5, price: 40)
+ProductImage.create!(product: prod, url: 'RattlesnakeRambleHoodie.png', alt_text: "Sweatshirt Front")
+prod = Product.create!(description: "Black, Cotton, Hooded, Uni-Sex Sweatshirt, size extra-large", quantity: 3, price: 40)
+ProductImage.create!(product: prod, url: 'RattlesnakeRambleHoodie.png', alt_text: "Sweatshirt Front")
 
-User.create(email: 'admin@example.com', password: 'password')
+User.create!(email: 'admin@example.com', password: 'password')


### PR DESCRIPTION
We're getting the following deprecation warning in development and test environments:
```
DEPRECATION WARNING: Leaving `ActiveRecord::ConnectionAdapters::SQLite3Adapter.represent_boolean_as_integer`
set to false is deprecated. SQLite databases have used 't' and 'f' to serialize
boolean values and must have old data converted to 1 and 0 (its native boolean
serialization) before setting this flag to true. Conversion can be accomplished
by setting up a rake task which runs

  ExampleModel.where("boolean_column = 't'").update_all(boolean_column: 1)
  ExampleModel.where("boolean_column = 'f'").update_all(boolean_column: 0)

for all models and all boolean columns, after which the flag must be set to
true by adding the following to your application.rb file:

  Rails.application.config.active_record.sqlite3.represent_boolean_as_integer = true
```
This MR fixes the warning by setting the config flag as recommended in the deprecation warning. It does not convert the development database to use boolean integers, but this can be accomplished by resetting and re-seeding the development database as follows:
```
rails db:reset
rails db:seed
```

The production database uses Postgres, so this fix does not affect the production environment.

This MR also updates the `db/seeds.rb` file by changing `create` to `create!` throughout. This results in Rails raising an error if any seed record cannot be created, instead of silently failing (which often results in harder-to-track failures down the line).