### PR TITLE
Warn the Admin if race edition dates are different

### DIFF
--- a/app/helpers/race_edition_helper.rb
+++ b/app/helpers/race_edition_helper.rb
@@ -14,4 +14,8 @@ module RaceEditionHelper
           RaceEditionPresenter.new(race_edition)
         end
   end
+
+  def race_editions_not_aligned?
+    current_full_course_edition.date != current_kids_course_edition.date
+  end
 end

--- a/app/views/pages/_date_alignment_warning.html.erb
+++ b/app/views/pages/_date_alignment_warning.html.erb
@@ -1,0 +1,9 @@
+<% if current_user && race_editions_not_aligned? %>
+  <div class="row">
+    <div class="alert alert-danger">
+      <p><b><%= "Warning: Full Course and Kids Course Race Edition dates are not aligned!" %></b></p>
+      <p><%= "Full course date: #{l current_full_course_edition.date, format: :long_with_day}" %></p>
+      <p><%= "Kids course date: #{l current_kids_course_edition.date, format: :long_with_day}" %></p>
+    </div>
+  </div>
+<% end %>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,3 +1,5 @@
+<%= render 'date_alignment_warning' %>
+
 <div class="panel panel-primary">
   <div class="panel-heading">
     <h3 class="panel-title"><%= "Rattlesnake Ramble #{current_full_course_edition.year} Information" %></h3>


### PR DESCRIPTION
Currently, if we set up a new Full Course race edition but forget to set up a new Kids Course race edition (or vice versa), the home page will dynamically generate what looks like correct information, but the sign up links will continue to go to the old race edition for the one we didn't set up.

This PR creates a warning that will display on the home page if the current Full Course and the current Kids Course race editions are not on the same date. 

The warning will display only if a user is logged in (i.e., only to an admin).

The warning looks like the screenshot below:

![Screen Shot 2020-10-13 at 9 03 22 AM](https://user-images.githubusercontent.com/14797300/95878939-05fea600-0d33-11eb-9655-15945e387dc3.png)