### PR TITLE
Remove rails_12factor gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,6 @@ end
 
 group :production do
   gem 'pg'
-  gem 'rails_12factor'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -175,11 +175,6 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
-    rails_12factor (0.0.3)
-      rails_serve_static_assets
-      rails_stdout_logging
-    rails_serve_static_assets (0.0.5)
-    rails_stdout_logging (0.0.5)
     railties (6.0.3.4)
       actionpack (= 6.0.3.4)
       activesupport (= 6.0.3.4)
@@ -296,7 +291,6 @@ DEPENDENCIES
   pry
   puma (~> 4.3)
   rails (~> 6.0)
-  rails_12factor
   rest-client (~> 2.0)
   rspec-rails
   sass-rails (~> 5.0)


### PR DESCRIPTION
The `rails_12factor` gem was needed to make Heroku function properly with a Rails 4 app. Rails 5+ apps do not require it, and as of Rails 6.0 it causes a deprecation warning to appear.

This MR removes the gem.

Addresses a portion of https://github.com/billwright/rattlesnake_ramble/issues/65