### PR TITLE
Swap out fix_lazy_capitalization callback in favor of capitalize_attributes gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ gem 'rest-client', '~> 2.0'
 gem 'dotenv-rails', '~> 2.2'
 gem 'strip_attributes', '~> 1.8'
 gem 'devise'
+gem 'capitalize_attributes'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,8 @@ GEM
       sassc (>= 2.0.0)
     builder (3.2.4)
     byebug (11.1.3)
+    capitalize_attributes (0.1.1)
+      activemodel (>= 5.0, < 7.0)
     capybara (2.18.0)
       addressable
       mini_mime (>= 0.1.3)
@@ -277,6 +279,7 @@ DEPENDENCIES
   bootstrap-datepicker-rails (~> 1.6)
   bootstrap-sass (~> 3.4.1)
   byebug
+  capitalize_attributes
   capybara (~> 2.13)
   chronic_duration
   devise

--- a/app/models/racer.rb
+++ b/app/models/racer.rb
@@ -1,15 +1,16 @@
 class Racer < ActiveRecord::Base
+  include CapitalizeAttributes
+
   has_many :race_entries, dependent: :destroy
   enum gender: [:male, :female]
+  capitalize_attributes :first_name, :last_name, :city
   strip_attributes collapse_spaces: true
 
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
-  LAZY_CAPITALIZATION_ATTRIBUTES = [:first_name, :last_name, :city]
 
   before_validation do
     downcase_email
     modernize_birth_date
-    fix_lazy_capitalization
   end
 
   validates :first_name, presence: true
@@ -46,17 +47,6 @@ class Racer < ActiveRecord::Base
       self.birth_date += 2000.years
     elsif birth_date.year <= Date.today.year % 100 + 100
       self.birth_date += 1900.years
-    end
-  end
-
-  def fix_lazy_capitalization
-    LAZY_CAPITALIZATION_ATTRIBUTES.each do |attribute|
-      value = send(attribute)
-      next unless value.present?
-
-      if (value == value.upcase) || (value == value.downcase)
-        self.assign_attributes(attribute => value.titleize)
-      end
     end
   end
 end

--- a/spec/models/racer_spec.rb
+++ b/spec/models/racer_spec.rb
@@ -12,8 +12,12 @@ require 'rails_helper'
 
 RSpec.describe Racer, type: :model do
   include ActiveSupport::Testing::TimeHelpers
+  it { is_expected.to capitalize_attribute(:first_name) }
+  it { is_expected.to capitalize_attribute(:last_name) }
+  it { is_expected.to capitalize_attribute(:city) }
+
   # strip_attribute tests do not work on first_name, last_name, or city
-  # because RSpec matcher is confused by the fix_lazy_capitalization validation
+  # because RSpec matcher is confused by the capitalize_attributes gem
   it { is_expected.to strip_attribute(:state).collapse_spaces }
   it { is_expected.to strip_attribute(:email).collapse_spaces }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,9 +15,11 @@
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 
 require 'strip_attributes/matchers'
+require 'capitalize_attributes/matchers'
 
 RSpec.configure do |config|
   config.include StripAttributes::Matchers
+  config.include CapitalizeAttributes::Matchers
 
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest


### PR DESCRIPTION
Uses the new `capitalize_attributes` gem instead of custom `fix_lazy_capitalization` callback in the Racer model.