### PR TITLE
Updating versions in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,11 @@
 # README
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+This is the repository for the Rattlesnake Ramble website, hosted at https://www.rattlesnakeramble.org.
 
-Things you may want to cover:
+Local setup requires the following:
 
-* Ruby version: 2.6
-
-* Rails version: 5.2
-
-* System dependencies
-
-* Configuration
-
-* Database creation
-
-* Database initialization
-
-* How to run the test suite
-
-* Services (job queues, cache servers, search engines, etc.)
-
-* Deployment instruction
+* Ruby version: 2.7
+* Rails version: 6.0
  
 ## Models
 


### PR DESCRIPTION
Bringing the README file up to date with the Ruby and Rails versions we're currently using (2.7 and 6.0, respectively).

This also serves the purpose of triggering a redeploy to address #108.