### PR TITLE
Hide admin buttons from visitors

### DIFF
--- a/app/views/race_editions/show.html.erb
+++ b/app/views/race_editions/show.html.erb
@@ -25,13 +25,17 @@
 </div>
 <hr/>
 
-<div class="row">
-  <div class="col">
-    <%= link_to "Edit Race Edition", edit_race_edition_path(@presenter), class: "btn btn-success btn-small" %>
+<% if current_user.present? %>
+  <div class="row">
+    <div class="col">
+      <%= link_to "Edit Race Edition", edit_race_edition_path(@presenter), class: "btn btn-success btn-small" %>
+    </div>
   </div>
-</div>
-<br/>
+  <br/>
+<% end %>
 
 <%= render 'race_entries/edition_entries', view_object: @presenter %>
 
-<h5><%= link_to "Return to Races Listing", races_path, class: "btn btn-warning btn-small" %></h5>
+<% if current_user.present? %>
+  <h5><%= link_to "Return to Races Listing", races_path, class: "btn btn-warning btn-small" %></h5>
+<% end %>


### PR DESCRIPTION
Currently, we are seeing two admin-only buttons on the Entrants list view. The buttons take the user to a login screen, so this is not a security problem. But it's a bit confusing to show those buttons at all to visitors.

This PR hides both of those buttons from visitors.