### PR TITLE
History for friendly_id slugs

### DIFF
--- a/app/models/race.rb
+++ b/app/models/race.rb
@@ -5,5 +5,5 @@ class Race < ActiveRecord::Base
   has_many :race_editions
   validates :name, presence: true, length: { minimum: 5, maximum: 100 }
   validates_uniqueness_of :name, case_sensitive: false
-  friendly_id :name, use: :slugged
+  friendly_id :name, use: [:slugged, :history]
 end

--- a/app/models/race_edition.rb
+++ b/app/models/race_edition.rb
@@ -10,7 +10,7 @@ class RaceEdition < ActiveRecord::Base
 
   accepts_nested_attributes_for :racers
   accepts_nested_attributes_for :race_entries
-  friendly_id :name, use: :slugged
+  friendly_id :name, use: [:slugged, :history]
 
   validates :race_id, presence: true
   validates :date, presence: true

--- a/db/migrate/20220807134041_create_friendly_id_slugs.rb
+++ b/db/migrate/20220807134041_create_friendly_id_slugs.rb
@@ -1,0 +1,15 @@
+class CreateFriendlyIdSlugs < ActiveRecord::Migration[6.0]
+  def change
+    create_table :friendly_id_slugs do |t|
+      t.string   :slug,           null: false
+      t.integer  :sluggable_id,   null: false
+      t.string   :sluggable_type, limit: 50
+      t.string   :scope
+      t.datetime :created_at
+    end
+    add_index :friendly_id_slugs, :sluggable_id
+    add_index :friendly_id_slugs, [:slug, :sluggable_type]
+    add_index :friendly_id_slugs, [:slug, :sluggable_type, :scope], unique: true
+    add_index :friendly_id_slugs, :sluggable_type
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,22 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_23_003948) do
+ActiveRecord::Schema.define(version: 2022_08_07_134041) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "friendly_id_slugs", force: :cascade do |t|
+    t.string "slug", null: false
+    t.integer "sluggable_id", null: false
+    t.string "sluggable_type", limit: 50
+    t.string "scope"
+    t.datetime "created_at"
+    t.index ["slug", "sluggable_type", "scope"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type_and_scope", unique: true
+    t.index ["slug", "sluggable_type"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type"
+    t.index ["sluggable_id"], name: "index_friendly_id_slugs_on_sluggable_id"
+    t.index ["sluggable_type"], name: "index_friendly_id_slugs_on_sluggable_type"
+  end
 
   create_table "product_images", force: :cascade do |t|
     t.integer "product_id", null: false

--- a/lib/tasks/friendly_id/update_slugs.rake
+++ b/lib/tasks/friendly_id/update_slugs.rake
@@ -1,0 +1,35 @@
+namespace :friendly_id do
+  desc "For a given model, adds all friendly_id slugs to the friendly_id_slugs table"
+  task :update_slugs, [:model] => :environment do |_, args|
+    start_time = Time.current
+    abort "No model specified" unless args.model
+
+    model = args.model.to_s.classify.constantize
+    puts "Updating #{model.count} #{model.to_s.pluralize}"
+    model.find_each do |resource|
+      current_resource = "#{model} #{resource.slug}"
+
+      if resource.update(slug: resource.slug)
+        puts "Updated slug for #{current_resource}"
+      else
+        abort "Could not update #{current_resource}"
+      end
+    end
+
+    elapsed_time = Time.current - start_time
+    puts "\nFinished friendly_id:update_slugs for model #{model} in #{elapsed_time} seconds"
+  end
+
+  desc "For all friendly_id models, adds friendly_id slugs to the friendly_id_slugs table"
+  task update_all_slugs: :environment do
+    start_time = Time.current
+
+    [:race, :race_edition].each do |model_name|
+      Rake::Task["friendly_id:update_slugs"].invoke(model_name)
+      Rake::Task["friendly_id:update_slugs"].reenable
+    end
+
+    elapsed_time = Time.current - start_time
+    puts "\nFinished friendly_id:update_slugs for all models in #{elapsed_time} seconds"
+  end
+end


### PR DESCRIPTION
To enable history tracking for friendly_id slugs, we need to add a database table. 

This PR includes the standard migration to add a `friendly_id_slugs` table. It also includes a rake task that will add existing slugs to the table.

Addresses #135 