### PR TITLE
Automatically change slugs and redirect

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,12 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
+
+  # If an old friendly id or a numeric id was used to find the record, then
+  # the request id will not match the current friendly id, and we should do
+  # a 301 redirect that uses the current friendly id.
+  def friendly_redirect(resource, id_param)
+    if request.request_method_symbol == :get && resource.friendly_id != id_param
+      redirect_to request.params.merge(id: resource.friendly_id), status: :moved_permanently
+    end
+  end
 end

--- a/app/controllers/race_editions_controller.rb
+++ b/app/controllers/race_editions_controller.rb
@@ -115,5 +115,7 @@ class RaceEditionsController < ApplicationController
 
   def set_race_edition
     @race_edition = RaceEdition.friendly.find(params[:id])
+
+    friendly_redirect(@race_edition, params[:id])
   end
 end

--- a/app/controllers/races_controller.rb
+++ b/app/controllers/races_controller.rb
@@ -42,5 +42,7 @@ class RacesController < ApplicationController
 
   def set_race
     @race = Race.friendly.find(params[:id])
+
+    friendly_redirect(@race, params[:id])
   end
 end

--- a/app/models/race.rb
+++ b/app/models/race.rb
@@ -6,4 +6,12 @@ class Race < ActiveRecord::Base
   validates :name, presence: true, length: { minimum: 5, maximum: 100 }
   validates_uniqueness_of :name, case_sensitive: false
   friendly_id :name, use: [:slugged, :history]
+
+  after_commit :update_edition_slugs
+
+  private
+
+  def update_edition_slugs
+    race_editions.each(&:save)
+  end
 end

--- a/app/models/race_edition.rb
+++ b/app/models/race_edition.rb
@@ -21,10 +21,16 @@ class RaceEdition < ActiveRecord::Base
   scope :full_course, -> { joins(:race).where.not(races: {name: "Rattlesnake Ramble Kids Race"}) }
 
   def name
-    "#{race&.name} on #{date}"
+    "#{race&.short_name} on #{date}"
   end
 
   def home_time_zone
     ::RambleConfig.home_time_zone
+  end
+
+  private
+
+  def should_generate_new_friendly_id?
+    true
   end
 end

--- a/spec/presenters/race_edition_presenter_spec.rb
+++ b/spec/presenters/race_edition_presenter_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe RaceEditionPresenter do
     end
 
     context 'when the race includes "kids" in the name' do
-      let(:race) { build_stubbed(:race, name: '2019 Ramble Kids') }
+      let(:race) { build_stubbed(:race, name: '2019 Ramble Kids', short_name: 'Kids Race') }
 
       it 'uses the kids categories' do
         expect(subject.category_size_map.size).to eq(2)


### PR DESCRIPTION
Currently, when a Race or Race Edition is changes, the slug does not change. Also, when a user requests a URL with an older slug, the user is shown the proper page but is not redirected to the new URL.

This PR adds automatic slug changes and also redirects when an older URL is requested.

In addition, the Race Edition slugs were getting quite long. This PR changes from using `race.name` + `date` to using `race.short_name` + `date`. 

We should run the `friendly_id:update_all_slugs` rake task after this PR is deployed.