### PR TITLE
Remove the enter_controller file (needed for zeitwerk compatibility)

### DIFF
--- a/app/controllers/enter_controller.rb
+++ b/app/controllers/enter_controller.rb
@@ -1,9 +1,0 @@
-class PagesController < ApplicationController
-  
-  def home
-  end
-  
-  def enter
-  end
-  
-end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,6 +1,9 @@
 class PagesController < ApplicationController
   include RaceReportsHelper
 
+  def enter
+  end
+
   def home
   end
 


### PR DESCRIPTION
Pushing up the Rails 6.1 configs (https://github.com/billwright/rattlesnake_ramble/pull/140) resulted in the app crashing with a zeitwerk error:
```
2022-09-05T23:51:16.497569+00:00 app[web.1]: Puma starting in single mode...
2022-09-05T23:51:16.497587+00:00 app[web.1]: * Puma version: 5.6.4 (ruby 2.7.6-p219) ("Birdie's Version")
2022-09-05T23:51:16.497587+00:00 app[web.1]: *  Min threads: 5
2022-09-05T23:51:16.497587+00:00 app[web.1]: *  Max threads: 5
2022-09-05T23:51:16.497587+00:00 app[web.1]: *  Environment: production
2022-09-05T23:51:16.497588+00:00 app[web.1]: *          PID: 4
2022-09-05T23:51:19.569447+00:00 app[web.1]: ! Unable to load application: Zeitwerk::NameError: expected file /app/app/controllers/enter_controller.rb to define constant EnterController, but didn't
2022-09-05T23:51:19.569539+00:00 app[web.1]: bundler: failed to load command: puma (/app/vendor/bundle/ruby/2.7.0/bin/puma)
2022-09-05T23:51:19.570401+00:00 app[web.1]: /app/vendor/bundle/ruby/2.7.0/gems/zeitwerk-2.6.0/lib/zeitwerk/loader/callbacks.rb:25:in `on_file_autoloaded': expected file /app/app/controllers/enter_controller.rb to define constant EnterController, but didn't (Zeitwerk::NameError)
```

It turns out there is a file called `controllers/enter_controller.rb` that opens the `PagesController` class and defines two actions, `#enter` and `#home`. The `#enter` action is used and does have a route and view, though the resulting page has only an oversized paypal button and does not appear to be ready for use in production. The `#home` action has no route pointing to it.

We already have a `controllers/pages_controller` file that, as expected, defines the `PagesController` class.

This PR moves the `#enter` action into the `pages_controller` file and removes the otherwise-unused `enter_controller` file in hopes that this will allow us to load Rails 6.1 configs. 