### PR TITLE
Streamline CI pipeline with bundle caching

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -30,12 +30,17 @@ jobs:
     steps:
     - name: Install PostgreSQL 11 client
       run: sudo apt-get -yqq install libpq-dev
-    - uses: actions/checkout@v2
-    - name: Set up Ruby
+
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set up Ruby and install gems
       uses: ruby/setup-ruby@v1
-    - name: Install dependencies
-      run: bundle install
-    - name: Run migrations
+      with:
+        bundler-cache: true
+
+    - name: Set up database and run migrations
       run: bin/rails db:setup RAILS_ENV=test
+
     - name: Run tests
       run: bundle exec rake

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is the repository for the Rattlesnake Ramble website, hosted at https://www
 Local setup requires the following:
 
 * Ruby version: 2.7
-* Rails version: 6.0
+* Rails version: 6.1
 * Postgres
 
 * Database creation


### PR DESCRIPTION
We are rebuilding the bundle with every CI pipeline run. This PR enables bundle caching, which should take a few minutes off most runs.