### PR TITLE
Include smtp-imap and smtp-pop in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,11 @@ gem 'strip_attributes', '~> 1.8'
 gem 'devise'
 gem 'capitalize_attributes'
 gem 'pg'
-gem 'net-smtp' # This can be removed after upgrading to Rails 7 (which requires it as a dependency)
+
+# These three can be removed after upgrading to Rails 7 (which requires them as dependencies)
+gem 'net-smtp', require: false
+gem 'net-imap', require: false
+gem 'net-pop', require: false
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,6 +142,10 @@ GEM
     mime-types-data (3.2022.0105)
     mini_mime (1.1.2)
     minitest (5.16.3)
+    net-imap (0.3.1)
+      net-protocol
+    net-pop (0.1.2)
+      net-protocol
     net-protocol (0.1.3)
       timeout
     net-smtp (0.3.3)
@@ -286,6 +290,7 @@ GEM
 PLATFORMS
   arm64-darwin-21
   x86_64-darwin-20
+  x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES
@@ -304,6 +309,8 @@ DEPENDENCIES
   jbuilder (~> 2.5)
   jquery-rails (~> 4.3)
   listen
+  net-imap
+  net-pop
   net-smtp
   pg
   pry


### PR DESCRIPTION
By including these additional gems, I believe we can get running on Heroku with Ruby 3.1 without upgrading (yet) to Rails 7.