### PR TITLE
Remove the unused PagesController#enter action with related route and view

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,9 +1,6 @@
 class PagesController < ApplicationController
   include RaceReportsHelper
 
-  def enter
-  end
-
   def home
   end
 

--- a/app/views/pages/enter.html.erb
+++ b/app/views/pages/enter.html.erb
@@ -1,7 +1,0 @@
-
-<form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
-  <input type="hidden" name="cmd" value="_s-xclick">
-  <input type="hidden" name="hosted_button_id" value="8FVTEVZD6YRRA">
-  <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_buynow_LG.gif" border="0" name="submit" alt="PayPal - The safer, easier way to pay online!">
-  <img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1">
-</form>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,6 @@ Rails.application.routes.draw do
   get 'welcome/index'
 
   get '/home', to: 'pages#home'
-  get '/enter', to: 'pages#enter'
   get '/thanks', to: 'pages#thanks'
   get '/charity', to: 'pages#charity'
   get '/race_reports', to: 'pages#race_reports'


### PR DESCRIPTION
This PR removes the legacy `PagesController#enter` action, route, and view, because it has been replaced by the newer `RaceEditionsController#enter` action.

Resolves #143