### PR TITLE
JSON endpoint for race_editions

### DIFF
--- a/app/controllers/race_editions_controller.rb
+++ b/app/controllers/race_editions_controller.rb
@@ -5,8 +5,12 @@ class RaceEditionsController < ApplicationController
   before_action :set_race_edition, except: [:index, :new, :create]
 
   def show
-    race_edition = RaceEdition.where(id: @race_edition).includes(:race, race_entries: :racer).first
-    @presenter = RaceEditionPresenter.new(race_edition, params)
+    @race_edition = RaceEdition.includes(:race, race_entries: :racer).find_by(id: @race_edition.id)
+
+    respond_to do |format|
+      format.html { @presenter = RaceEditionPresenter.new(@race_edition, params) }
+      format.json
+    end
   end
 
   def new

--- a/app/views/race_editions/show.json.jbuilder
+++ b/app/views/race_editions/show.json.jbuilder
@@ -1,0 +1,27 @@
+json.(
+  @race_edition,
+    :date,
+    :default_start_time_male,
+    :default_start_time_female,
+    :entry_fee,
+    :created_at,
+    :updated_at,
+)
+
+json.race do
+  json.name @race_edition.race.name
+end
+
+json.race_entries @race_edition.race_entries do |race_entry|
+  json.bib_number race_entry.bib_number
+  json.scheduled_start_time race_entry.scheduled_start_time
+  json.racer do
+    json.first_name race_entry.racer.first_name
+    json.last_name race_entry.racer.last_name
+    json.gender race_entry.racer.gender
+    json.birth_date race_entry.racer.birth_date
+    json.email race_entry.racer.email
+    json.city race_entry.racer.city
+    json.state race_entry.racer.state
+  end
+end


### PR DESCRIPTION
This PR adds a JSON response for the `GET /race_editions/:id` endpoint. The response includes information about the race edition with its associated race, race entries, and racers.

We should consider adding a simple authentication method to protect race entrant's birthdates and email addresses.