### PR TITLE
Add a JSON index endpoint for Race Editions

### DIFF
--- a/app/controllers/race_editions_controller.rb
+++ b/app/controllers/race_editions_controller.rb
@@ -1,8 +1,14 @@
 # frozen_string_literal: true
 
 class RaceEditionsController < ApplicationController
-  before_action :authenticate_user!, except: [:show, :enter, :create_entry]
+  before_action :authenticate_user!, except: [:index, :show, :enter, :create_entry]
   before_action :set_race_edition, except: [:index, :new, :create]
+
+  def index
+    respond_to do |format|
+      format.json { authenticate_with_params! }
+    end
+  end
 
   def show
     @race_edition = RaceEdition.includes(:race, race_entries: :racer).find_by(id: @race_edition.id)

--- a/app/views/race_editions/index.json.jbuilder
+++ b/app/views/race_editions/index.json.jbuilder
@@ -1,0 +1,5 @@
+json.array! RaceEdition.includes(:race).all.find_each do |race_edition|
+  json.id race_edition.id
+  json.date race_edition.date
+  json.race_name race_edition.race.name
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ Rails.application.routes.draw do
   resources :races
   resources :racers
   
-  resources :race_editions, except: :index do
+  resources :race_editions do
     member do
       get 'enter'
       post 'create_entry'


### PR DESCRIPTION
In order to determine which race editions should be connected to OST, we need a JSON endpoint that returns race editions.

This PR adds that endpoint and protects it with authentication via query params, the same as for the JSON show endpoint.