### PR TITLE
Fix postgres config file

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -3,11 +3,13 @@ default: &default
   encoding: utf8
   pool: 5
   timeout: 5000
+  username: <%= ENV["POSTGRES_USER"] || 'postgres' %>
+  password: <%= ENV["POSTGRES_PASSWORD"] || 'postgres' %>
 
 development:
   <<: *default
   database: rr-development
-  username: postgres
+  host: localhost
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
@@ -15,5 +17,4 @@ development:
 test:
   <<: *default
   database: rr-test
-  username: <%= ENV["POSTGRES_USER"] || 'postgres' %>
-  password: <%= ENV["POSTGRES_PASSWORD"] || 'postgres' %>
+  host: localhost

--- a/config/database.yml
+++ b/config/database.yml
@@ -8,7 +8,6 @@ development:
   <<: *default
   database: rr-development
   username: postgres
-  host: localhost
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
@@ -18,4 +17,3 @@ test:
   database: rr-test
   username: <%= ENV["POSTGRES_USER"] || 'postgres' %>
   password: <%= ENV["POSTGRES_PASSWORD"] || 'postgres' %>
-  host: localhost


### PR DESCRIPTION
We are seeing

`ActiveRecord::ConnectionNotEstablished: fe_sendauth: no password supplied`

when running postgres on some local installations. This should fix the problem.