### PR TITLE
Link to Edit Racer

### DIFF
--- a/app/controllers/racers_controller.rb
+++ b/app/controllers/racers_controller.rb
@@ -32,7 +32,7 @@ class RacersController < ApplicationController
     @racer = Racer.find(params[:id])
     if @racer.update(obj_params)
       flash[:success] = "Your racer was updated successfully"
-      redirect_to racer_path(@racer)
+      redirect_to params.dig(:racer, :return_to) || racer_path(@racer)
     end
   end
 

--- a/app/controllers/racers_controller.rb
+++ b/app/controllers/racers_controller.rb
@@ -32,7 +32,7 @@ class RacersController < ApplicationController
     @racer = Racer.find(params[:id])
     if @racer.update(obj_params)
       flash[:success] = "Your racer was updated successfully"
-      redirect_to params.dig(:racer, :return_to) || racer_path(@racer)
+      redirect_to params[:return_to] || racer_path(@racer)
     end
   end
 

--- a/app/views/race_entries/_form.html.erb
+++ b/app/views/race_entries/_form.html.erb
@@ -3,17 +3,12 @@
 <div class="row">
   <div class="well col-md-8 col-md-offset-2">
     <%= form_for @race_entry do |f| %>
-
-      <%= f.label 'Racer name:' %>
-      <%= "#{@race_entry.racer&.name}" %>
+      <%= "Racer: #{@race_entry.racer&.name}, #{@race_entry.racer&.gender}, #{@race_entry.racer&.birth_date}" %>
+      <% if @race_entry.racer.present? %>
+        <hr/>
+        <%= link_to "Edit Racer", edit_racer_path(@race_entry.racer, return_to: edit_race_entry_path(@race_entry)), class: "btn btn-sm btn-success" %>
+      <% end %>
       <hr/>
-
-      <%= f.label 'Gender:' %>
-      <%= "#{@race_entry.racer&.gender}" %>
-      <hr/>
-
-      <!-- TODO: What I really want to do here is something like this to edit the gender of this entry -->
-      <!--      f.select @race_entry.racer&.gender, Racer.genders.keys-->
 
       <%= f.label :bib_number %>
       <%= f.text_field :bib_number, autofocus: true %>

--- a/app/views/race_entries/_form.html.erb
+++ b/app/views/race_entries/_form.html.erb
@@ -2,13 +2,16 @@
 
 <div class="row">
   <div class="well col-md-8 col-md-offset-2">
-    <%= form_for @race_entry do |f| %>
-      <%= "Racer: #{@race_entry.racer&.name}, #{@race_entry.racer&.gender}, #{@race_entry.racer&.birth_date}" %>
+    <h4>
+      <%= "Racer: #{@race_entry.racer&.name}, #{@race_entry.racer&.gender}, #{@race_entry.racer&.birth_date.present? ? l(@race_entry.racer.birth_date, format: :long) : nil}" %>
       <% if @race_entry.racer.present? %>
         <hr/>
         <%= link_to "Edit Racer", edit_racer_path(@race_entry.racer, return_to: edit_race_entry_path(@race_entry)), class: "btn btn-sm btn-success" %>
       <% end %>
-      <hr/>
+    </h4>
+  </div>
+  <div class="well col-md-8 col-md-offset-2">
+    <%= form_for @race_entry do |f| %>
 
       <%= f.label :bib_number %>
       <%= f.text_field :bib_number, autofocus: true %>

--- a/app/views/racers/_form.html.erb
+++ b/app/views/racers/_form.html.erb
@@ -27,6 +27,8 @@
 
       <%= f.label :state %>
       <%= f.text_field :state %>
+
+      <%= f.hidden_field :return_to, value: params[:return_to] %>
       
       <%= f.submit(@racer.new_record? ? 'Create Racer' : 'Update Racer', class: "btn btn-success") %>
     <% end %>

--- a/app/views/racers/_form.html.erb
+++ b/app/views/racers/_form.html.erb
@@ -28,7 +28,7 @@
       <%= f.label :state %>
       <%= f.text_field :state %>
 
-      <%= f.hidden_field :return_to, value: params[:return_to] %>
+      <%= hidden_field_tag :return_to, params[:return_to] %>
       
       <%= f.submit(@racer.new_record? ? 'Create Racer' : 'Update Racer', class: "btn btn-success") %>
     <% end %>

--- a/app/views/racers/edit.html.erb
+++ b/app/views/racers/edit.html.erb
@@ -1,3 +1,3 @@
-<%= render 'shared/page_title', title: "Edit Racer" + @racer.name %>
+<%= render 'shared/page_title', title: "Edit Racer " + @racer.name %>
 
 <%= render 'form' %>


### PR DESCRIPTION
In #190, we suggested a Racer's birthdate should be editable from the Race Entry page. Because Racer is the parent record of the related Race Entry, this is not easily done.

This PR instead adds a handy link to reach the Racers Edit page directly from the Race Entries Edit page. It also stores a `return_to` param, which allows the Racer Update action to return the user to the Race Entries Edit page seamlessly.