### PR TITLE
Default sort unpaid entries first in Race_edition_presenter.rb

### DIFF
--- a/app/presenters/race_edition_presenter.rb
+++ b/app/presenters/race_edition_presenter.rb
@@ -71,6 +71,10 @@ class RaceEditionPresenter < SimpleDelegator
   end
 
   def sort_param
-    params[:sort] || 'race_entries.bib_number,racers.last_name'
+    if params[:sort].present?
+      params[:sort]
+    else
+      'race_entries.paid ASC, race_entries.bib_number, racers.last_name'
+    end
   end
 end


### PR DESCRIPTION
Sets default sort in RaceEditionPresenter to show unpaid entries first. Helps admins quickly spot unpaid racers. 
