### PR TITLE
feat: implement pay-first registration flow

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -299,6 +299,7 @@ PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-darwin-20
   x86_64-darwin-21
   x86_64-linux

--- a/app/views/race_editions/race_entries.html.erb
+++ b/app/views/race_editions/race_entries.html.erb
@@ -1,4 +1,15 @@
 <h1>Race Entries for <%= @race_edition.name %></h1>
 <hr/>
 
+<% if current_user.present? %>
+  <div class="row">
+    <div class="col">
+      <%= link_to "Unpaid Emails",
+          racer_emails_race_edition_path(@race_edition, filter: { paid: 'false' }),
+          class: "btn btn-danger btn-small" %>
+    </div>
+  </div>
+  <br/>
+<% end %>
+
 <%= render 'race_entries/entries', race_entries: @race_edition.sorted_race_entries %>

--- a/app/views/race_editions/show.html.erb
+++ b/app/views/race_editions/show.html.erb
@@ -34,17 +34,6 @@
   <br/>
 <% end %>
 
-<% if current_user.present? %>
-  <div class="row">
-    <div class="col">
-      <%= link_to "Unpaid Emails",
-          racer_emails_race_edition_path(@presenter, filter: { paid: 'false' }),
-          class: "btn btn-danger btn-small" %>
-    </div>
-  </div>
-  <br/>
-<% end %>
-
 
 <%= render 'race_entries/edition_entries', view_object: @presenter %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,8 @@ Rails.application.routes.draw do
       get 'racer_emails'
       get 'racer_info_csv'
       get 'race_entries'
+      get 'payment_success'
+      get 'payment_cancelled'
     end
   end
   


### PR DESCRIPTION
- Refactored race registration to create RaceEntry only after successful PayPal return
- Added payment_success and payment_cancelled actions to RaceEditionsController
- Updated routes for new callbacks
- Updated race_entries and show views accordingly
- Keeps old flow (successful_entry/cancelled_payment on RaceEntry) intact for backward compatibility
