### PR TITLE
Add admin-only Check-In Sheet feature

### DIFF
--- a/app/controllers/race_editions_controller.rb
+++ b/app/controllers/race_editions_controller.rb
@@ -181,6 +181,13 @@ class RaceEditionsController < ApplicationController
     redirect_to race_edition_path(@race_edition)
   end
 
+  def checkin_sheet
+    @race_edition = RaceEdition.friendly.find(params[:id])
+    @entries = @race_edition.race_entries.order(:bib_number)
+    render :checkin_sheet
+  end
+
+
   private
 
   def obj_params

--- a/app/views/race_editions/checkin_sheet.html.erb
+++ b/app/views/race_editions/checkin_sheet.html.erb
@@ -1,0 +1,35 @@
+<h2 style="text-align: center; margin-bottom: 20px;">
+  Check-In Sheet — <%= @race_edition.name %>
+</h2>
+
+<table style="width: 100%; border-collapse: collapse; font-family: Arial, sans-serif; font-size: 14px;">
+  <thead>
+    <tr style="background-color: #f2f2f2;">
+      <th style="border: 1px solid #ddd; padding: 8px; text-align: left;">Name</th>
+      <th style="border: 1px solid #ddd; padding: 8px; text-align: left;">Bib #</th>
+      <th style="border: 1px solid #ddd; padding: 8px; text-align: center;">Check-In</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @entries.each do |entry| %>
+      <tr>
+        <td style="border: 1px solid #ddd; padding: 8px;">
+          <%= entry.racer.first_name %> <%= entry.racer.last_name %>
+        </td>
+        <td style="border: 1px solid #ddd; padding: 8px;">
+          <%= entry.bib_number.presence || "-" %>
+        </td>
+        <td style="border: 1px solid #ddd; padding: 8px; text-align: center;">
+          <input type="checkbox" style="transform: scale(1.3);" />
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<div style="text-align: center; margin-top: 30px;">
+  <button onclick="window.print()" 
+          style="padding: 10px 20px; background-color: #007bff; border: none; color: white; cursor: pointer; border-radius: 4px;">
+    Print This Sheet
+  </button>
+</div>

--- a/app/views/race_editions/race_entries.html.erb
+++ b/app/views/race_editions/race_entries.html.erb
@@ -7,6 +7,13 @@
       <%= link_to "Unpaid Emails",
           racer_emails_race_edition_path(@race_edition, filter: { paid: 'false' }),
           class: "btn btn-danger btn-small" %>
+    
+      <% if current_user.admin? %>
+        <%= link_to "Print CheckIn Sheet",
+            checkin_sheet_race_edition_path(@race_edition),
+            class: "btn btn-primary btn-small ms-2",
+            target: "_blank" %>
+      <% end %>
     </div>
   </div>
   <br/>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,8 @@ Rails.application.routes.draw do
       get 'race_entries'
       get 'payment_success'
       get 'payment_cancelled'
+      get 'checkin_sheet'
+
     end
   end
   

--- a/db/migrate/20251106220220_add_admin_to_users.rb
+++ b/db/migrate/20251106220220_add_admin_to_users.rb
@@ -1,0 +1,5 @@
+class AddAdminToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :admin, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_06_26_020154) do
+ActiveRecord::Schema[7.0].define(version: 2025_11_06_220220) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -106,6 +106,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_06_26_020154) do
     t.string "encrypted_password", default: "", null: false
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
+    t.boolean "admin", default: false
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 


### PR DESCRIPTION
### Summary
Adds a new "Print Check-In Sheet" button to the Race Entries page for admin users.

### Details
- Added `checkin_sheet` route under `race_editions`
- Added controller action using `RaceEdition.friendly.find`
- Created new view (`checkin_sheet.html.erb`) with printable table
- Button appears only for admin users (`current_user.admin?`)
- Includes migration for `admin` column in users table

### Verification
- Visit /race_editions/full-course-on-2026-09-19/race_entries
- Click “Print Check-In Sheet” → printable sheet displays correctly
