### PR TITLE
Fixed the print preview popup

### DIFF
--- a/app/assets/javascripts/checkin_print.js
+++ b/app/assets/javascripts/checkin_print.js
@@ -1,0 +1,58 @@
+(function () {
+  function handleCheckinPrint(event) {
+    event.preventDefault();
+
+    var link = event.currentTarget;
+    var url = link && link.getAttribute('href');
+    if (!url) { return; }
+
+    var existingFrame = document.getElementById('checkin-sheet-print-frame');
+    if (existingFrame && existingFrame.parentNode) {
+      existingFrame.parentNode.removeChild(existingFrame);
+    }
+
+    var iframe = document.createElement('iframe');
+    iframe.id = 'checkin-sheet-print-frame';
+    iframe.style.position = 'fixed';
+    iframe.style.right = '0';
+    iframe.style.bottom = '0';
+    iframe.style.width = '0';
+    iframe.style.height = '0';
+    iframe.style.border = '0';
+    iframe.style.visibility = 'hidden';
+
+    iframe.addEventListener('load', function () {
+      try {
+        iframe.contentWindow.focus();
+        iframe.contentWindow.print();
+      } catch (error) {
+        console.error('Check-in sheet print failed', error);
+        window.location = url;
+      }
+
+      setTimeout(function () {
+        if (iframe.parentNode) {
+          iframe.parentNode.removeChild(iframe);
+        }
+      }, 1000);
+    });
+
+    iframe.addEventListener('error', function () {
+      window.location = url;
+    });
+
+    iframe.src = url;
+    document.body.appendChild(iframe);
+  }
+
+  function initializeCheckinPrint() {
+    var links = document.querySelectorAll('[data-checkin-print]');
+    Array.prototype.forEach.call(links, function (link) {
+      if (link.dataset.checkinPrintBound === 'true') { return; }
+      link.addEventListener('click', handleCheckinPrint);
+      link.dataset.checkinPrintBound = 'true';
+    });
+  }
+
+  document.addEventListener('turbolinks:load', initializeCheckinPrint);
+})();

--- a/app/views/race_editions/race_entries.html.erb
+++ b/app/views/race_editions/race_entries.html.erb
@@ -12,7 +12,7 @@
         <%= link_to "Print CheckIn Sheet",
             checkin_sheet_race_edition_path(@race_edition),
             class: "btn btn-primary btn-small ms-2",
-            target: "_blank" %>
+            data: { checkin_print: true } %>
       <% end %>
     </div>
   </div>


### PR DESCRIPTION
1) Admin “Print CheckIn Sheet” now opens the browser print dialog immediately without leaving the page, by loading the sheet in a hidden iframe (app/views/race_editions/race_entries.html.erb, app/assets/javascripts/checkin_print.js).

2) The check-in sheet page still has its “Print This Sheet” button so direct visits can print normally.