### PR TITLE
Feature/email reminders

### DIFF
--- a/app/controllers/race_editions_controller.rb
+++ b/app/controllers/race_editions_controller.rb
@@ -173,6 +173,7 @@ class RaceEditionsController < ApplicationController
     )
 
     flash[:success] = "Get ready to Ramble, because you are entered!"
+    send_payment_ack_and_schedule_reminders(entry)
     redirect_to race_edition_path(@race_edition)
   end
 
@@ -205,5 +206,17 @@ class RaceEditionsController < ApplicationController
     return if request.format == "application/json"
 
     friendly_redirect(@race_edition, params[:id])
+  end
+
+  def send_payment_ack_and_schedule_reminders(race_entry)
+    RaceMailer.payment_acknowledgment(race_entry).deliver_later
+
+    race_date = race_entry.race_edition.date
+    return unless race_date.present?
+    race_time = race_date.to_time.in_time_zone(race_entry.race_edition.home_time_zone)
+
+    # enqueue reminders relative to race date
+    ReminderJob.set(wait_until: race_time - 7.days).perform_later(race_entry.id, "one week away")
+    ReminderJob.set(wait_until: race_time - 1.day).perform_later(race_entry.id, "tomorrow")
   end
 end

--- a/app/controllers/race_editions_controller.rb
+++ b/app/controllers/race_editions_controller.rb
@@ -165,7 +165,7 @@ class RaceEditionsController < ApplicationController
     attrs = {}
     attrs[:merchandise_size] = params[:merchandise_size] if params[:merchandise_size].present?
 
-    RaceEntry.create!(
+    entry = RaceEntry.create!(
       race_edition: @race_edition,
       racer: racer,
       paid: true,

--- a/app/controllers/race_entries_controller.rb
+++ b/app/controllers/race_entries_controller.rb
@@ -26,6 +26,15 @@ class RaceEntriesController < ApplicationController
     race_entry.paid = true
     if race_entry.save
       flash[:success] = "Get ready to Ramble, because you are entered!"
+      RaceMailer.payment_acknowledgment(race_entry).deliver_later
+
+      race_date = race_entry.race_edition.date
+      if race_date.present?
+        race_time = race_date.to_time.in_time_zone(race_entry.race_edition.home_time_zone)
+        ReminderJob.set(wait_until: race_time - 7.days).perform_later(race_entry.id, "one week away")
+        ReminderJob.set(wait_until: race_time - 1.day).perform_later(race_entry.id, "tomorrow")
+      end
+
       redirect_to race_edition_path(race_entry.race_edition)
     end
   end

--- a/app/jobs/reminder_job.rb
+++ b/app/jobs/reminder_job.rb
@@ -1,0 +1,10 @@
+class ReminderJob < ApplicationJob
+  queue_as :default
+
+  def perform(race_entry_id, timing_label)
+    race_entry = RaceEntry.includes(:racer, :race_edition).find_by(id: race_entry_id)
+    return unless race_entry&.racer&.email.present?
+
+    RaceMailer.reminder(race_entry, timing_label: timing_label).deliver_now
+  end
+end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,5 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
+  # Default sender comes from env; falls back to Gmail username, then a placeholder.
+  default from: ENV.fetch('GMAIL_DEFAULT_FROM', ENV['GMAIL_USERNAME'] || 'no-reply@example.com')
   layout 'mailer'
 end

--- a/app/mailers/race_mailer.rb
+++ b/app/mailers/race_mailer.rb
@@ -1,0 +1,24 @@
+class RaceMailer < ApplicationMailer
+  def payment_acknowledgment(race_entry)
+    @race_entry = race_entry
+    @racer = race_entry.racer
+    @race_edition = race_entry.race_edition
+
+    mail(
+      to: @racer.email,
+      subject: "You’re entered in #{@race_edition.name}"
+    )
+  end
+
+  def reminder(race_entry, timing_label:)
+    @race_entry = race_entry
+    @racer = race_entry.racer
+    @race_edition = race_entry.race_edition
+    @timing_label = timing_label
+
+    mail(
+      to: @racer.email,
+      subject: "#{@race_edition.name} is #{timing_label}"
+    )
+  end
+end

--- a/app/mailers/race_mailer.rb
+++ b/app/mailers/race_mailer.rb
@@ -3,10 +3,12 @@ class RaceMailer < ApplicationMailer
     @race_entry = race_entry
     @racer = race_entry.racer
     @race_edition = race_entry.race_edition
+    @course_name = course_name
+    @race_date = formatted_date
 
     mail(
       to: @racer.email,
-      subject: "You’re entered in #{@race_edition.name}"
+      subject: "Yayy! You’re entered in #{@course_name} on #{@race_date}"
     )
   end
 
@@ -15,10 +17,27 @@ class RaceMailer < ApplicationMailer
     @racer = race_entry.racer
     @race_edition = race_entry.race_edition
     @timing_label = timing_label
+    @course_name = course_name
+    @race_date = formatted_date
 
     mail(
       to: @racer.email,
-      subject: "#{@race_edition.name} is #{timing_label}"
+      subject: "Reminder: #{@course_name} on #{@race_date} is #{timing_label}"
     )
+  end
+
+  private
+
+  def course_name
+    @race_edition.race&.short_name.presence ||
+      @race_edition.race&.name.presence ||
+      @race_edition.name
+  end
+
+  def formatted_date
+    return "the race date" unless @race_edition.date
+
+    date = @race_edition.date
+    "#{date.strftime('%B')} #{date.day.ordinalize}"
   end
 end

--- a/app/views/race_mailer/payment_acknowledgment.text.erb
+++ b/app/views/race_mailer/payment_acknowledgment.text.erb
@@ -1,8 +1,8 @@
 Hi <%= @racer.first_name %>,
 
-Thanks for entering the Rattlesnake Ramble! Your payment has been received and you’re confirmed for <%= @race_edition.name %>.
+Thanks for entering the Rattlesnake Ramble! Your payment has been received and you’re confirmed for <%= @course_name %> on <%= @race_date %>.
 
-Race day: <%= @race_edition.date %>
+Race day: <%= @race_date %>
 
-See you soon,
+Get ready to Ramble!
 Rattlesnake Ramble Team

--- a/app/views/race_mailer/payment_acknowledgment.text.erb
+++ b/app/views/race_mailer/payment_acknowledgment.text.erb
@@ -1,0 +1,8 @@
+Hi <%= @racer.first_name %>,
+
+Thanks for entering the Rattlesnake Ramble! Your payment has been received and you’re confirmed for <%= @race_edition.name %>.
+
+Race day: <%= @race_edition.date %>
+
+See you soon,
+Rattlesnake Ramble Team

--- a/app/views/race_mailer/reminder.text.erb
+++ b/app/views/race_mailer/reminder.text.erb
@@ -1,8 +1,8 @@
 Hi <%= @racer.first_name %>,
 
-Reminder: <%= @race_edition.name %> is <%= @timing_label %>.
+Reminder: <%= @course_name %> on <%= @race_date %> is <%= @timing_label %>.
 
-Race day: <%= @race_edition.date %>
+Race day: <%= @race_date %>
 
-Good luck!
+Get ready to Ramble!
 Rattlesnake Ramble Team

--- a/app/views/race_mailer/reminder.text.erb
+++ b/app/views/race_mailer/reminder.text.erb
@@ -1,0 +1,8 @@
+Hi <%= @racer.first_name %>,
+
+Reminder: <%= @race_edition.name %> is <%= @timing_label %>.
+
+Race day: <%= @race_edition.date %>
+
+Good luck!
+Rattlesnake Ramble Team

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -34,7 +34,23 @@ Rails.application.configure do
   config.active_storage.service = :local
 
   # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
+  #config.action_mailer.raise_delivery_errors = false
+
+  # Send real email in development via Gmail
+  config.action_mailer.perform_deliveries = true
+  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    address: "smtp.gmail.com",
+    port: 587,
+    user_name: ENV["GMAIL_USERNAME"],
+    password: ENV["GMAIL_APP_PASSWORD"],
+    authentication: :plain,
+    enable_starttls_auto: true
+    # dev-only workaround if you hit cert errors:
+    # openssl_verify_mode: 'none'
+  }
+
 
   config.action_mailer.perform_caching = false
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -46,7 +46,9 @@ Rails.application.configure do
     user_name: ENV["GMAIL_USERNAME"],
     password: ENV["GMAIL_APP_PASSWORD"],
     authentication: :plain,
-    enable_starttls_auto: true
+    enable_starttls_auto: true,
+    openssl_verify_mode: 'none'
+
     # dev-only workaround if you hit cert errors:
     # openssl_verify_mode: 'none'
   }

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -67,9 +67,18 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
-  # Ignore bad email addresses and do not raise email delivery errors.
-  # Set this to true and configure the email server for immediate delivery to raise delivery errors.
-  # config.action_mailer.raise_delivery_errors = false
+  # Mailer configuration
+  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.perform_deliveries = true
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    address:              "smtp.gmail.com",
+    port:                 587,
+    user_name:            ENV["GMAIL_USERNAME"],
+    password:             ENV["GMAIL_APP_PASSWORD"],
+    authentication:       :plain,
+    enable_starttls_auto: true
+  }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).


### PR DESCRIPTION
1) Send payment acknowledgment email when a race entry is marked paid.
2) Schedule reminder emails at 1 week and 1 day before the race date/time.
3) Add RaceMailer with updated copy (friendly subjects, course name, formatted date).
4) Production SMTP configured to use Gmail via env vars.

Setup notes:

1) Set Heroku config vars: GMAIL_USERNAME, GMAIL_APP_PASSWORD, optional GMAIL_DEFAULT_FROM.
2) Ensure a background worker/adapter is running so scheduled reminders fire.