### PR TITLE
Add automatic bib number assignment

### DIFF
--- a/app/controllers/race_editions_controller.rb
+++ b/app/controllers/race_editions_controller.rb
@@ -196,7 +196,7 @@ class RaceEditionsController < ApplicationController
 
   def obj_params
     params.require(:race_edition)
-      .permit(:race_id, :date, :entry_fee, :default_start_time_male_local, :default_start_time_female_local, :accepting_entries, :selling_merchandise, :merchandise_description, :merchandise_image_file_name, :merchandise_price,
+      .permit(:race_id, :date, :entry_fee, :default_start_time_male_local, :default_start_time_female_local, :next_male_bib_number, :next_female_bib_number, :next_kids_bib_number, :accepting_entries, :selling_merchandise, :merchandise_description, :merchandise_image_file_name, :merchandise_price,
               racers_attributes: [:id, :first_name, :last_name, :email, :gender, :birth_date, :city, :state],
               race_entries_attributes: [:elapsed_predicted_time, :merchandise_size])
   end

--- a/app/models/race_edition.rb
+++ b/app/models/race_edition.rb
@@ -2,6 +2,7 @@ class RaceEdition < ActiveRecord::Base
   extend FriendlyId
   include TimeZonable
 
+  KIDS_RACE_NAME = "Rattlesnake Ramble Kids Race".freeze
   MERCHANDISE_SIZES = ["Women S", "Women M", "Women L", "Men S", "Men M", "Men L", "Men XL"]
 
   belongs_to :race
@@ -19,10 +20,13 @@ class RaceEdition < ActiveRecord::Base
   validates :entry_fee, presence: true
   validates :default_start_time_male, presence: true
   validates :default_start_time_female, presence: true
+  validates :next_male_bib_number, numericality: { only_integer: true, greater_than: 0 }, allow_nil: true
+  validates :next_female_bib_number, numericality: { only_integer: true, greater_than: 0 }, allow_nil: true
+  validates :next_kids_bib_number, numericality: { only_integer: true, greater_than: 0 }, allow_nil: true
   validates_uniqueness_of :race_id, scope: :date
 
-  scope :kids_race, -> { joins(:race).where(races: {name: "Rattlesnake Ramble Kids Race"}) }
-  scope :full_course, -> { joins(:race).where.not(races: {name: "Rattlesnake Ramble Kids Race"}) }
+  scope :kids_race, -> { joins(:race).where(races: {name: KIDS_RACE_NAME}) }
+  scope :full_course, -> { joins(:race).where.not(races: {name: KIDS_RACE_NAME}) }
 
   def name
     "#{race&.short_name} on #{date}"
@@ -32,7 +36,30 @@ class RaceEdition < ActiveRecord::Base
     ::RambleConfig.home_time_zone
   end
 
+  def kids_race?
+    race&.name == KIDS_RACE_NAME
+  end
+
+  def assign_next_bib_number_for!(racer)
+    column = bib_number_column_for(racer)
+    next_bib_number = public_send(column)
+    return if next_bib_number.blank?
+
+    while race_entries.exists?(bib_number: next_bib_number)
+      next_bib_number += 1
+    end
+
+    update_column(column, next_bib_number + 1)
+    next_bib_number
+  end
+
   private
+
+  def bib_number_column_for(racer)
+    return :next_kids_bib_number if kids_race?
+
+    racer.male? ? :next_male_bib_number : :next_female_bib_number
+  end
 
   def should_generate_new_friendly_id?
     true

--- a/app/models/race_entry.rb
+++ b/app/models/race_entry.rb
@@ -18,6 +18,7 @@ class RaceEntry < ActiveRecord::Base
                           message: 'may not be duplicated within a race edition'
 
   after_initialize :default_values
+  before_validation :assign_bib_number, on: :create, if: -> { bib_number.blank? }
 
   attr_accessor :category_name
   delegate :date, to: :race_edition
@@ -50,5 +51,15 @@ class RaceEntry < ActiveRecord::Base
 
   def name
     "#{racer.name}'s entry into #{race_edition.name}"
+  end
+
+  private
+
+  def assign_bib_number
+    return unless racer && race_edition
+
+    race_edition.with_lock do
+      self.bib_number = race_edition.assign_next_bib_number_for!(racer)
+    end
   end
 end

--- a/app/views/race_editions/_form.html.erb
+++ b/app/views/race_editions/_form.html.erb
@@ -5,7 +5,7 @@
     <%= form_for @race_edition do |f| %>
       <%= f.label :race %>
       <%= f.select :race_id, Race.all.map { |race| [race.name, race.id] },
-                   {prompt: true}, {class: "form-control dropdown-select-field"} %>
+                   {prompt: true}, {class: "form-control dropdown-select-field", id: "race_edition_race_id"} %>
 
       <%= f.label :date %>
       <%= datepicker_input(form: f,
@@ -22,6 +22,21 @@
 
       <%= f.label 'Female default start time' %>
       <%= f.text_field :default_start_time_female_local, placeholder: 'hh:mm' %>
+
+      <% kids_race_selected = @race_edition.kids_race? %>
+
+      <div id="full-course-bib-fields" style="<%= 'display: none;' if kids_race_selected %>">
+        <%= f.label 'Male bib number' %>
+        <%= f.number_field :next_male_bib_number, min: 1 %>
+
+        <%= f.label 'Female bib number' %>
+        <%= f.number_field :next_female_bib_number, min: 1 %>
+      </div>
+
+      <div id="kids-bib-fields" style="<%= 'display: none;' unless kids_race_selected %>">
+        <%= f.label 'Next available bib number' %>
+        <%= f.number_field :next_kids_bib_number, min: 1 %>
+      </div>
 
       <%= f.label 'Accepting Entries' %>
       <%= f.check_box :accepting_entries %>
@@ -48,3 +63,37 @@
     <% end %>
   </div>
 </div>
+
+<script>
+  (function() {
+    function selectedRaceText(raceSelect) {
+      var option = raceSelect.options[raceSelect.selectedIndex];
+      return option ? option.text : '';
+    }
+
+    function toggleBibFields() {
+      var raceSelect = document.getElementById('race_edition_race_id');
+      var fullCourseFields = document.getElementById('full-course-bib-fields');
+      var kidsFields = document.getElementById('kids-bib-fields');
+      if (!raceSelect || !fullCourseFields || !kidsFields) return;
+
+      var selectedText = selectedRaceText(raceSelect);
+      var isKidsRace = selectedText.indexOf('Kids Race') !== -1;
+
+      fullCourseFields.style.display = isKidsRace ? 'none' : '';
+      kidsFields.style.display = isKidsRace ? '' : 'none';
+    }
+
+    function bindBibFieldToggle() {
+      var raceSelect = document.getElementById('race_edition_race_id');
+      if (!raceSelect) return;
+
+      toggleBibFields();
+      raceSelect.removeEventListener('change', toggleBibFields);
+      raceSelect.addEventListener('change', toggleBibFields);
+    }
+
+    document.addEventListener('turbolinks:load', bindBibFieldToggle);
+    document.addEventListener('DOMContentLoaded', bindBibFieldToggle);
+  })();
+</script>

--- a/db/migrate/20260313180000_add_next_bib_numbers_to_race_editions.rb
+++ b/db/migrate/20260313180000_add_next_bib_numbers_to_race_editions.rb
@@ -1,0 +1,7 @@
+class AddNextBibNumbersToRaceEditions < ActiveRecord::Migration[7.0]
+  def change
+    add_column :race_editions, :next_male_bib_number, :integer
+    add_column :race_editions, :next_female_bib_number, :integer
+    add_column :race_editions, :next_kids_bib_number, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_11_06_220220) do
+ActiveRecord::Schema[7.0].define(version: 2026_03_13_180000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -57,6 +57,9 @@ ActiveRecord::Schema[7.0].define(version: 2025_11_06_220220) do
     t.string "merchandise_description"
     t.string "merchandise_image_file_name"
     t.integer "merchandise_price"
+    t.integer "next_male_bib_number"
+    t.integer "next_female_bib_number"
+    t.integer "next_kids_bib_number"
     t.index ["race_id", "date"], name: "index_race_editions_on_race_id_and_date", unique: true
     t.index ["race_id"], name: "index_race_editions_on_race_id"
     t.index ["slug"], name: "index_race_editions_on_slug", unique: true

--- a/spec/factories/race.rb
+++ b/spec/factories/race.rb
@@ -1,5 +1,20 @@
 FactoryBot.define do
   factory :race do
     name { FFaker::Product.product_name }
+
+    trait :odd_years do
+      name { "Rattlesnake Ramble Trail Race - Odd Years" }
+      short_name { "Full Course" }
+    end
+
+    trait :even_years do
+      name { "Rattlesnake Ramble Trail Race - Even Years" }
+      short_name { "Full Course" }
+    end
+
+    trait :kids_race do
+      name { "Rattlesnake Ramble Kids Race" }
+      short_name { "Kids Course" }
+    end
   end
 end

--- a/spec/factories/race.rb
+++ b/spec/factories/race.rb
@@ -5,16 +5,31 @@ FactoryBot.define do
     trait :odd_years do
       name { "Rattlesnake Ramble Trail Race - Odd Years" }
       short_name { "Full Course" }
+      initialize_with do
+        Race.find_or_initialize_by(name: name).tap do |race|
+          race.short_name = short_name
+        end
+      end
     end
 
     trait :even_years do
       name { "Rattlesnake Ramble Trail Race - Even Years" }
       short_name { "Full Course" }
+      initialize_with do
+        Race.find_or_initialize_by(name: name).tap do |race|
+          race.short_name = short_name
+        end
+      end
     end
 
     trait :kids_race do
       name { "Rattlesnake Ramble Kids Race" }
       short_name { "Kids Course" }
+      initialize_with do
+        Race.find_or_initialize_by(name: name).tap do |race|
+          race.short_name = short_name
+        end
+      end
     end
   end
 end

--- a/spec/factories/race_edition.rb
+++ b/spec/factories/race_edition.rb
@@ -5,5 +5,13 @@ FactoryBot.define do
     entry_fee { rand(10..1000) }
     default_start_time_male { date }
     default_start_time_female { date }
+
+    trait :full_course do
+      association :race, :odd_years
+    end
+
+    trait :kids_race do
+      association :race, :kids_race
+    end
   end
 end

--- a/spec/models/race_edition_spec.rb
+++ b/spec/models/race_edition_spec.rb
@@ -35,6 +35,12 @@ RSpec.describe RaceEdition, type: :model do
       expect(race_edition).to be_invalid
       expect(race_edition.errors.full_messages).to include('Race has already been taken')
     end
+
+    it 'is invalid with a non-positive next male bib number' do
+      race_edition = build_stubbed(:race_edition, next_male_bib_number: 0)
+      expect(race_edition).to be_invalid
+      expect(race_edition.errors.full_messages).to include('Next male bib number must be greater than 0')
+    end
   end
 
   describe '#default_start_time_female_local= and #default_start_time_male_local=' do
@@ -71,6 +77,16 @@ RSpec.describe RaceEdition, type: :model do
         expect(subject.default_start_time_female).to eq('2020-09-12 07:45:00-0600'.to_datetime)
         expect(subject.default_start_time_male).to eq('2020-09-12 07:30:00-0600'.to_datetime)
       end
+    end
+  end
+
+  describe '#kids_race?' do
+    it 'returns true for kids race editions' do
+      expect(build_stubbed(:race_edition, :kids_race)).to be_kids_race
+    end
+
+    it 'returns false for full course editions' do
+      expect(build_stubbed(:race_edition, :full_course)).not_to be_kids_race
     end
   end
 end

--- a/spec/models/race_entry_spec.rb
+++ b/spec/models/race_entry_spec.rb
@@ -50,6 +50,49 @@ RSpec.describe RaceEntry, type: :model do
     end
   end
 
+  describe 'automatic bib assignment' do
+    it 'assigns and increments the male bib number for full course entries' do
+      race_edition = create(:race_edition, :full_course, next_male_bib_number: 101, next_female_bib_number: 201)
+      race_entry = create(:race_entry, race_edition: race_edition, racer: create(:racer, :male))
+
+      expect(race_entry.bib_number).to eq(101)
+      expect(race_edition.reload.next_male_bib_number).to eq(102)
+    end
+
+    it 'assigns and increments the female bib number for full course entries' do
+      race_edition = create(:race_edition, :full_course, next_male_bib_number: 101, next_female_bib_number: 201)
+      race_entry = create(:race_entry, race_edition: race_edition, racer: create(:racer, :female))
+
+      expect(race_entry.bib_number).to eq(201)
+      expect(race_edition.reload.next_female_bib_number).to eq(202)
+    end
+
+    it 'assigns and increments the kids bib number for kids race entries' do
+      race_edition = create(:race_edition, :kids_race, next_kids_bib_number: 301)
+      race_entry = create(:race_entry, race_edition: race_edition, racer: create(:racer, :female))
+
+      expect(race_entry.bib_number).to eq(301)
+      expect(race_edition.reload.next_kids_bib_number).to eq(302)
+    end
+
+    it 'skips bib numbers that are already used in the edition' do
+      race_edition = create(:race_edition, :full_course, next_male_bib_number: 101, next_female_bib_number: 201)
+      create(:race_entry, race_edition: race_edition, racer: create(:racer, :male), bib_number: 101)
+
+      race_entry = create(:race_entry, race_edition: race_edition, racer: create(:racer, :male))
+
+      expect(race_entry.bib_number).to eq(102)
+      expect(race_edition.reload.next_male_bib_number).to eq(103)
+    end
+
+    it 'leaves bib_number blank when no next bib number is configured' do
+      race_edition = create(:race_edition, :full_course, next_male_bib_number: nil, next_female_bib_number: nil)
+      race_entry = create(:race_entry, race_edition: race_edition, racer: create(:racer, :male))
+
+      expect(race_entry.bib_number).to be_nil
+    end
+  end
+
   describe 'time-related virtual attributes' do
     real_attributes = [:predicted_time, :time]
 


### PR DESCRIPTION
## Summary
- add next bib number fields to race editions
- auto-assign bib numbers for male, female, and kids entries
- show only the relevant bib fields in the admin race edition form

## Testing
- manually verified registration flow
- simulated PayPal success callback
- confirmed bib numbers are assigned and increment correctly
